### PR TITLE
Introduce TLS client-side connection

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,6 +6,7 @@ rustflags = [
 	"-C", "linker-flavor=ld",
 	"--cfg", "aes_force_soft",
 	"--cfg", "polyval_force_soft",
+	"--cfg", "curve25519_dalek_backend=\"serial\"",
 ]
 
 [target.x86_64-unknown-linux-gnu]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,6 +665,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "enumn"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2295,6 +2301,7 @@ name = "virtio-drivers"
 version = "0.7.5"
 dependencies = [
  "bitflags 2.9.1",
+ "embedded-io",
  "enumn",
  "log",
  "zerocopy 0.8.26",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "vsock",
 ]
 
 [[package]]
@@ -339,6 +340,12 @@ name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cipher"
@@ -1363,6 +1370,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2305,6 +2325,16 @@ dependencies = [
  "enumn",
  "log",
  "zerocopy 0.8.26",
+]
+
+[[package]]
+name = "vsock"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e8b4d00e672f147fc86a09738fadb1445bd1c0a40542378dfb82909deeee688"
+dependencies = [
+ "libc",
+ "nix",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,6 +561,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,6 +722,12 @@ dependencies = [
  "rand_core",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fnv"
@@ -1252,6 +1283,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "libaproxy"
 version = "0.1.0"
 dependencies = [
@@ -1287,6 +1327,12 @@ dependencies = [
  "cfg-if",
  "windows-targets 0.53.2",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libtcgtpm"
@@ -1393,10 +1439,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1405,6 +1488,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1464,6 +1548,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "p384"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1518,6 +1614,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1553,6 +1660,15 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy 0.8.26",
+]
 
 [[package]]
 name = "prettyplease"
@@ -1621,6 +1737,26 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
 
 [[package]]
 name = "rand_core"
@@ -1717,6 +1853,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core",
+ "sha2",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1735,6 +1906,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1878,6 +2082,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1945,21 +2155,31 @@ dependencies = [
  "cocoon-tpm-tpm2-interface",
  "cocoon-tpm-utils-common",
  "cpuarch",
+ "der",
+ "ecdsa",
  "elf",
  "gdbstub",
  "gdbstub_arch",
+ "getrandom 0.2.16",
+ "hmac",
  "igvm_defs",
  "intrusive-collections",
  "kbs-types",
  "libaproxy",
  "libtcgtpm",
  "log",
+ "p256",
  "packit",
+ "pkcs8",
+ "rand_core",
  "release",
+ "rsa",
  "rustc_version",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
+ "signature",
  "syscall",
  "test",
  "uuid",
@@ -1968,6 +2188,7 @@ dependencies = [
  "verus_stub",
  "virtio-drivers",
  "vstd",
+ "x25519-dalek",
  "zerocopy 0.8.26",
 ]
 
@@ -2229,6 +2450,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -2612,6 +2839,16 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core",
+]
 
 [[package]]
 name = "xbuild"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,18 @@ vstd = { git = "https://github.com/verus-lang/verus", rev ="6c66898", features =
 verify_proof = { path = "verify_proof", default-features = false  }
 verify_external = { path = "verify_external", default-features = false  }
 
+rustls = { version = "0.23.31", default-features = false }
+hmac = { version="0.12", default-features= false }
+ecdsa = { version = "0.16.8", default-features=false }
+der =  { version = "0.7", default-features = false  }
+p256 ={ version = "0.13.2", default-features = false }
+pkcs8 = {version = "0.10.2", default-features = false }
+rsa = { version = "0.9", default-features = false }
+signature = {version = "2", default-features = false }
+x25519-dalek =  {version = "2", default-features = false }
+getrandom = { version = "0.2", default-features = false }
+rand_core = { version = "0.6.4", default-features = false }
+
 [profile.release]
 panic = 'abort'
 

--- a/Documentation/docs/developer/RUNTIME_CONFIG.md
+++ b/Documentation/docs/developer/RUNTIME_CONFIG.md
@@ -1,0 +1,11 @@
+# SVSM runtime configuration
+
+Some SVSM parameters can be configured from the host using the QEMU command
+line option `-fw_cfg`
+
+## Attestation: opt/org.svsm/VsockAttestPort
+
+By default, vsock uses port 1995 for attestation. This option enables the use
+of a different port.
+
+`scripts/launch_guest.sh [..] -- -fw_cfg name=opt/org.svsm/VsockAttestPort,string=1234`

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SVSM_ARGS += --features ${FEATURES}
 XBUILD_ARGS += -f ${FEATURES}
 endif
 
-FEATURES_TEST ?= vtpm,virtio-drivers
+FEATURES_TEST ?= vtpm,virtio-drivers,vsock
 SVSM_ARGS_TEST += --no-default-features
 ifneq ($(FEATURES_TEST),)
 SVSM_ARGS_TEST += --features ${FEATURES_TEST}

--- a/aproxy/Cargo.toml
+++ b/aproxy/Cargo.toml
@@ -13,6 +13,7 @@ clap = { version = "4.5", features = ["derive"] }
 libaproxy.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+vsock = "0.5.1"
 
 [lints]
 workspace = true

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -72,6 +72,7 @@ test.workspace = true
 
 [features]
 attest = ["dep:aes", "dep:base64", "dep:cocoon-tpm-crypto", "dep:cocoon-tpm-tpm2-interface", "dep:cocoon-tpm-utils-common", "dep:kbs-types", "dep:libaproxy", "dep:serde", "dep:serde_json"]
+vsock = []
 
 default = []
 enable-gdb = ["dep:gdbstub", "dep:gdbstub_arch"]

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -67,13 +67,26 @@ verify_proof = { workspace = true, optional = true}
 verify_external = { workspace = true, optional = true}
 verus_stub = { workspace = true }
 
+rustls = { workspace = true, optional = true }
+getrandom = { workspace = true, optional = true, features = ["custom"] }
+hmac = { workspace = true, optional = true }
+ecdsa = { workspace = true, optional = true, features = ["pem"] }
+der =  { workspace = true, optional = true, features = ["alloc"] }
+p256 = { workspace = true, optional = true, features = ["alloc", "ecdsa", "pkcs8"] }
+pkcs8 = { workspace = true, optional = true, features = ["alloc"] }
+rsa = { workspace = true, optional = true, features = ["sha2"] }
+signature = { workspace = true, optional = true }
+x25519-dalek =  { workspace = true, optional = true }
+rand_core = { workspace = true, optional = true, features= ["getrandom"] }
+
 [target."x86_64-unknown-none".dev-dependencies]
 test.workspace = true
 
 [features]
 attest = ["dep:aes", "dep:base64", "dep:cocoon-tpm-crypto", "dep:cocoon-tpm-tpm2-interface", "dep:cocoon-tpm-utils-common", "dep:kbs-types", "dep:libaproxy", "dep:serde", "dep:serde_json"]
 vsock = []
-
+tls = ["dep:rustls", "dep:getrandom", "vsock", "virtio-drivers", "rustcrypto"]
+rustcrypto = ["dep:hmac", "dep:ecdsa", "dep:der", "dep:p256", "dep:pkcs8", "dep:rsa", "dep:signature", "dep:x25519-dalek", "dep:rand_core","dep:aes"]
 default = []
 enable-gdb = ["dep:gdbstub", "dep:gdbstub_arch"]
 vtpm = ["dep:libtcgtpm"]

--- a/kernel/build.rs
+++ b/kernel/build.rs
@@ -40,6 +40,7 @@ fn main() {
     println!("cargo:rerun-if-changed=kernel/src/svsm.lds");
     println!("cargo:rerun-if-changed=build.rs");
     init_verify();
+    insert_ca_cert();
 }
 
 fn init_verify() {
@@ -55,5 +56,34 @@ fn init_verify() {
             "-Z unstable-options",
         ];
         println!("cargo:rustc-env=VERUS_ARGS={}", verus_args.join(" "));
+    }
+}
+
+fn insert_ca_cert() {
+    if cfg!(not(feature = "tls")) {
+        return;
+    }
+
+    let ca_cert_path = std::path::Path::new(std::env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("Failed to get parent directory")
+        .join("certificates")
+        .join("ca.der");
+    if ca_cert_path.exists() {
+        return;
+    }
+
+    let script_path = std::path::Path::new(std::env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("Failed to get parent directory")
+        .join("scripts")
+        .join("gen_ca_server_certs.sh");
+
+    let status = std::process::Command::new("sh")
+        .arg(&script_path)
+        .status()
+        .expect("Failed to execute process");
+    if !status.success() {
+        panic!("CA cert generation script failed");
     }
 }

--- a/kernel/src/attest.rs
+++ b/kernel/src/attest.rs
@@ -9,11 +9,17 @@ extern crate alloc;
 
 use crate::{
     error::SvsmError,
+    fw_cfg::FwCfg,
     greq::{pld_report::*, services::get_regular_report},
     io::{Read, Write, DEFAULT_IO_DRIVER},
+    platform::SVSM_PLATFORM,
     serial::SerialPort,
     utils::vec::{try_to_vec, vec_sized},
 };
+
+#[cfg(feature = "vsock")]
+use crate::vsock::virtio_vsock::VsockStream;
+
 use aes::{cipher::BlockDecrypt, Aes256Dec};
 use aes_gcm::KeyInit;
 use alloc::{string::ToString, vec::Vec};
@@ -39,20 +45,43 @@ use sha2::{Digest, Sha512};
 use zerocopy::{FromBytes, IntoBytes};
 
 enum Transport<'a> {
+    #[cfg(feature = "vsock")]
+    Vsock(VsockStream),
     Serial(SerialPort<'a>),
 }
 
 impl Transport<'_> {
     fn write(&mut self, buf: &[u8]) -> Result<usize, SvsmError> {
         match self {
+            #[cfg(feature = "vsock")]
+            Transport::Vsock(vsock) => vsock.write(buf),
             Transport::Serial(serial) => serial.write(buf),
         }
     }
 
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, SvsmError> {
         match self {
+            #[cfg(feature = "vsock")]
+            Transport::Vsock(vsock) => vsock.read(buf),
             Transport::Serial(serial) => serial.read(buf),
         }
+    }
+}
+
+fn create_serial_transport<'a>() -> Transport<'a> {
+    let sp = SerialPort::new(&DEFAULT_IO_DRIVER, 0x3e8); // COM3
+    sp.init();
+    Transport::Serial(sp)
+}
+
+#[cfg(feature = "vsock")]
+fn get_vsock_attest_port() -> u32 {
+    pub const VSOCK_ATTEST_DEFAULT_PORT: u32 = 1995;
+
+    let cfg = FwCfg::new(SVSM_PLATFORM.get_io_port());
+    match cfg.get_vsock_attest_port() {
+        Ok(port) => port,
+        Err(_) => VSOCK_ATTEST_DEFAULT_PORT,
     }
 }
 
@@ -71,8 +100,6 @@ impl TryFrom<Tee> for AttestationDriver<'_> {
     fn try_from(tee: Tee) -> Result<Self, Self::Error> {
         // TODO: Make the IO port configurable/discoverable for other transport mechanisms such as
         // virtio-vsock.
-        let sp = SerialPort::new(&DEFAULT_IO_DRIVER, 0x3e8); // COM3
-        sp.init();
 
         match tee {
             Tee::Snp => (),
@@ -82,7 +109,23 @@ impl TryFrom<Tee> for AttestationDriver<'_> {
         let curve = Curve::new(TpmEccCurve::NistP521).map_err(AttestationError::Crypto)?;
         let ecc = sc_key_generate(&curve).map_err(AttestationError::Crypto)?;
 
-        let transport = Transport::Serial(sp);
+        let transport = {
+            #[cfg(feature = "vsock")]
+            {
+                match VsockStream::connect(1234, get_vsock_attest_port(), 2) {
+                    Ok(value) => Transport::Vsock(value),
+                    Err(e) => {
+                        log::info!("{:?} Falling back to the serial", e);
+                        create_serial_transport()
+                    }
+                }
+            }
+            #[cfg(not(feature = "vsock"))]
+            {
+                create_serial_transport()
+            }
+        };
+
         Ok(Self {
             transport,
             tee,

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -33,6 +33,8 @@ use crate::task::TaskError;
 use crate::tdx::TdxError;
 #[cfg(feature = "virtio-drivers")]
 use crate::virtio::VirtioError;
+#[cfg(feature = "vsock")]
+use crate::vsock::VsockError;
 use elf::ElfError;
 use syscall::SysCallError;
 
@@ -129,6 +131,9 @@ pub enum SvsmError {
     /// Errors related to attesting SVSM's launch evidence.
     #[cfg(feature = "attest")]
     TeeAttestation(AttestationError),
+    /// Errors related to vsock.
+    #[cfg(feature = "vsock")]
+    Vsock(VsockError),
 }
 
 impl From<ElfError> for SvsmError {
@@ -165,6 +170,13 @@ impl From<VirtioError> for SvsmError {
 impl From<BlockDeviceError> for SvsmError {
     fn from(err: BlockDeviceError) -> Self {
         Self::Block(err)
+    }
+}
+
+#[cfg(feature = "vsock")]
+impl From<VsockError> for SvsmError {
+    fn from(err: VsockError) -> Self {
+        Self::Vsock(err)
     }
 }
 

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -31,6 +31,8 @@ use crate::sev::SevSnpError;
 use crate::syscall::ObjError;
 use crate::task::TaskError;
 use crate::tdx::TdxError;
+#[cfg(feature = "tls")]
+use crate::tls::error::TlsError;
 #[cfg(feature = "virtio-drivers")]
 use crate::virtio::VirtioError;
 #[cfg(feature = "vsock")]
@@ -134,6 +136,9 @@ pub enum SvsmError {
     /// Errors related to vsock.
     #[cfg(feature = "vsock")]
     Vsock(VsockError),
+    // Errors related to TLS.
+    #[cfg(feature = "tls")]
+    Tls(TlsError),
 }
 
 impl From<ElfError> for SvsmError {
@@ -177,6 +182,13 @@ impl From<BlockDeviceError> for SvsmError {
 impl From<VsockError> for SvsmError {
     fn from(err: VsockError) -> Self {
         Self::Vsock(err)
+    }
+}
+
+#[cfg(feature = "tls")]
+impl From<TlsError> for SvsmError {
+    fn from(err: TlsError) -> Self {
+        Self::Tls(err)
     }
 }
 

--- a/kernel/src/fw_cfg.rs
+++ b/kernel/src/fw_cfg.rs
@@ -186,6 +186,15 @@ impl<'a> FwCfg<'a> {
         T::read_from_bytes(buffer.as_slice()).map_err(|_| FwCfgError::InvalidFormat)
     }
 
+    #[cfg(all(feature = "attest", feature = "vsock"))]
+    pub fn get_vsock_attest_port(&self) -> Result<u32, SvsmError> {
+        let mut it = FwCfgFileIterator::new(self, "opt/org.svsm/VsockAttestPort")?;
+        let data = Self::read_from_it::<[u8; 4]>(&mut it)?;
+        String::from_utf8_lossy(&data)
+            .parse::<u32>()
+            .map_err(|_| SvsmError::FwCfg(FwCfgError::InvalidFormat))
+    }
+
     pub fn get_virtio_mmio_addresses(&self) -> Result<Vec<u64>, SvsmError> {
         use hardware_info::*;
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -46,6 +46,8 @@ pub mod utils;
 #[cfg(feature = "virtio-drivers")]
 pub mod virtio;
 pub mod vmm;
+#[cfg(feature = "vsock")]
+pub mod vsock;
 #[cfg(all(feature = "vtpm", not(test)))]
 pub mod vtpm;
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -41,6 +41,8 @@ pub mod svsm_paging;
 pub mod syscall;
 pub mod task;
 pub mod tdx;
+#[cfg(feature = "tls")]
+pub mod tls;
 pub mod types;
 pub mod utils;
 #[cfg(feature = "virtio-drivers")]

--- a/kernel/src/mm/address_space.rs
+++ b/kernel/src/mm/address_space.rs
@@ -159,7 +159,7 @@ pub const SIZE_LEVEL1: usize = 1usize << ((9 * 1) + 12);
 pub const SIZE_LEVEL0: usize = 1usize << ((9 * 0) + 12);
 
 // Stack definitions
-pub const STACK_PAGES: usize = 8;
+pub const STACK_PAGES: usize = 16;
 pub const STACK_SIZE: usize = PAGE_SIZE * STACK_PAGES;
 pub const STACK_GUARD_SIZE: usize = STACK_SIZE;
 pub const STACK_TOTAL_SIZE: usize = STACK_SIZE + STACK_GUARD_SIZE;

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -397,6 +397,11 @@ pub fn svsm_main(cpu_index: usize) {
         // TLS library uses (for the moment) getrandom crate
         // This is not the final implementation, just a placeholder
         register_custom_getrandom!(custom_getrandom);
+        // Uncomment one of the following lines to run the corresponding test
+        use svsm::tls::examples::test_https;
+        test_https();
+        // use svsm::tls::examples::test_command_server;
+        // test_command_server();
     }
 
     // Start request processing on this CPU if required.

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -63,6 +63,11 @@ use release::COCONUT_VERSION;
 #[cfg(feature = "attest")]
 use kbs_types::Tee;
 
+#[cfg(feature = "tls")]
+use getrandom::register_custom_getrandom;
+#[cfg(feature = "tls")]
+use svsm::tls::random::custom_getrandom;
+
 extern "C" {
     static bsp_stack: u8;
     static bsp_stack_end: u8;
@@ -383,6 +388,15 @@ pub fn svsm_main(cpu_index: usize) {
     match exec_user("/init", opendir("/").expect("Failed to find FS root")) {
         Ok(_) => (),
         Err(e) => log::info!("Failed to launch /init: {e:?}"),
+    }
+
+    #[cfg(feature = "tls")]
+    {
+        // Register the custom getrandom implementation for SVSM
+        // This is required for TLS to work
+        // TLS library uses (for the moment) getrandom crate
+        // This is not the final implementation, just a placeholder
+        register_custom_getrandom!(custom_getrandom);
     }
 
     // Start request processing on this CPU if required.

--- a/kernel/src/testing.rs
+++ b/kernel/src/testing.rs
@@ -42,6 +42,8 @@ pub enum IORequest {
     GetLaunchMeasurement = 0x01,
     /// Virtio-blk tests: Get Sha256 hash of the svsm state disk image
     GetStateImageSha256 = 0x02,
+    /// Virtio-vsock tests: Ask host to start a vsock server
+    StartVsockServer = 0x03,
 }
 
 /// Return the serial port to communicate with the host for a given request

--- a/kernel/src/tls/buffer.rs
+++ b/kernel/src/tls/buffer.rs
@@ -1,0 +1,123 @@
+// Buffer management for TLS records
+extern crate alloc;
+use super::constant::{FIRST_LEN_BYTE_POS, HEADER_LEN, SECOND_LEN_BYTE_POS};
+use super::error::TlsError;
+use alloc::vec;
+use alloc::vec::Vec;
+
+/// A buffer structure to manage TLS records, allowing for efficient reading and writing
+/// of data while handling partial reads/writes and discarding processed data.
+#[derive(Debug)]
+pub struct TlsBuffer {
+    // The underlying byte buffer
+    buf: Vec<u8>,
+    // The first used (valid, non-discarded) byte in the buffer
+    head: usize,
+    // The first unused byte in the buffer
+    tail: usize,
+}
+
+// fixme: input buffer is different from output buffer
+// maybe we should have two different structs
+
+impl TlsBuffer {
+    /// Create a new [`TlsBuffer`] with the specified size
+    pub fn new(size: usize) -> Self {
+        Self {
+            buf: vec![0u8; size],
+            head: 0,
+            tail: 0,
+        }
+    }
+
+    /// Get a mutable reference to the currently used portion of the buffer
+    pub fn curr_used_buf_as_mut(&mut self) -> &mut [u8] {
+        &mut self.buf[self.head..self.tail]
+    }
+
+    /// Get a reference to the currently used portion of the buffer
+    pub fn curr_used_buf_as_ref(&self) -> &[u8] {
+        &self.buf[self.head..self.tail]
+    }
+
+    /// Get a mutable reference to the remaining (unused) portion of the buffer
+    pub fn remaining_buf_as_mut(&mut self) -> &mut [u8] {
+        &mut self.buf[self.tail..]
+    }
+
+    /// Get a reference to the remaining (unused) portion of the buffer of the specified size
+    pub fn mutable_slice_from_remaining(&mut self, size: usize) -> Result<&mut [u8], TlsError> {
+        if self.tail + size > self.buf.len() {
+            return Err(TlsError::BufferTooSmall);
+        }
+        Ok(&mut self.buf[self.tail..self.tail + size])
+    }
+
+    /// From the current position (tail), extract the length of the TLS record
+    /// by reading the appropriate bytes in the TLS header.
+    pub fn extract_record_len_from_current_position(&self) -> Result<usize, TlsError> {
+        if self.tail + HEADER_LEN > self.buf.len() {
+            return Err(TlsError::BufferTooSmall);
+        }
+        Ok(((self.buf[self.tail + SECOND_LEN_BYTE_POS] as usize) << 8)
+            | (self.buf[self.tail + FIRST_LEN_BYTE_POS] as usize))
+    }
+
+    /// Advance the tail pointer by `n` bytes, marking them as used
+    pub fn advance_used(&mut self, n: usize) -> Result<(), TlsError> {
+        if self.tail + n > self.buf.len() {
+            return Err(TlsError::BufferTooSmall);
+        }
+        self.tail += n;
+        Ok(())
+    }
+
+    /// Reset the buffer to an empty state, discarding all used data
+    pub fn reset_used(&mut self) {
+        self.head = 0;
+        self.tail = 0;
+    }
+
+    /// Ensure that there is enough space in the buffer for `needed` bytes.
+    /// Try to compact the buffer, i.e., discard unused data from the front.
+    /// Returns an error if the buffer is still too small.
+    pub fn ensure_space(&mut self, needed: usize) -> Result<(), TlsError> {
+        let remaining_space = self.buf.len() - self.tail;
+
+        if remaining_space >= needed {
+            return Ok(());
+        }
+
+        self.compact();
+
+        let remaining_space_after_compact = self.buf.len() - self.tail;
+        if remaining_space_after_compact < needed {
+            return Err(TlsError::BufferTooSmall);
+        }
+
+        Ok(())
+    }
+
+    /// Discard n bytes from the start of the used buffer.
+    pub fn move_head(&mut self, n: usize) {
+        self.head += n;
+        if self.head > self.tail {
+            self.head = self.tail; // Prevent discarding more than tail
+        }
+    }
+
+    /// Compact the buffer by moving the used data to the front and adjusting head and tail pointers
+    fn compact(&mut self) {
+        if self.head == 0 {
+            return;
+        }
+        log::info!(
+            "Compacting buffer, tail: {}, discarding: {}",
+            self.tail,
+            self.head
+        );
+        self.buf.copy_within(self.head..self.tail, 0);
+        self.tail -= self.head;
+        self.head = 0;
+    }
+}

--- a/kernel/src/tls/connection.rs
+++ b/kernel/src/tls/connection.rs
@@ -1,0 +1,423 @@
+//! This module is responsible for managing TLS connections.
+//! It uses rustls unbuffered API, which are suitable for no_std environments.
+//! The module provides a TlsClient struct to create and configure TLS connections,
+//! and a TlsConnection struct to manage individual TLS connections over VsockStream.
+//! The TlsConnection struct, thanks to the provided API, manages the TLS state machine,
+//! including handshake, reading and writing application data, and closing the connection.
+
+extern crate alloc;
+use alloc::sync::Arc;
+
+use super::buffer::TlsBuffer;
+use super::constant::{HEADER_LEN, IN_BUF_SIZE, OUT_BUF_SIZE};
+use super::crypto_provider::provider;
+use super::error::TlsError;
+use super::time_provider::FixedTimeProvider;
+
+use crate::error::SvsmError;
+use crate::io::{Read, Write};
+use crate::vsock::virtio_vsock::VsockStream;
+
+use rustls::client::{ClientConnectionData, UnbufferedClientConnection};
+use rustls::pki_types::{CertificateDer, DnsName, ServerName};
+use rustls::unbuffered::{
+    AppDataRecord, ConnectionState, EncodeTlsData, UnbufferedStatus, WriteTraffic,
+};
+use rustls::{ClientConfig, RootCertStore};
+
+/// The [`TlsClient`] struct is responsible for creating and configuring [`TlsConnection`] instances.
+#[derive(Debug)]
+pub struct TlsClient {
+    config: Arc<ClientConfig>,
+}
+
+impl TlsClient {
+    /// Create a new [`TlsClient`] with optional debug information
+    pub fn new(debug_info: bool) -> Self {
+        let config =
+            Self::create_client_config(debug_info).expect("Failed to create TLS client config");
+        Self { config }
+    }
+
+    /// Establish a TLS connection over a given [`VsockStream`]
+    pub fn connect(
+        &self,
+        sock: VsockStream,
+        server_name: &str,
+    ) -> Result<TlsConnection, SvsmError> {
+        let conn = UnbufferedClientConnection::new(
+            self.config.clone(),
+            Self::server_name_from_str(server_name)?,
+        )
+        .map_err(TlsError::from)?;
+        Ok(TlsConnection::new(sock, conn))
+    }
+
+    /// Create a TLS client configuration, which includes setting up root certificates, a time provider, and a crypto provider.
+    fn create_client_config(debug_info: bool) -> Result<Arc<ClientConfig>, TlsError> {
+        let crypto_provider = provider();
+        let time_provider = FixedTimeProvider::december_2025();
+
+        let mut root_store = RootCertStore::empty();
+
+        root_store.add(CertificateDer::from_slice(include_bytes!(
+            "../../../certificates/ca.der"
+        )))?;
+
+        let mut config =
+            ClientConfig::builder_with_details(Arc::new(crypto_provider), Arc::new(time_provider))
+                .with_protocol_versions(&[&rustls::version::TLS13])?
+                .with_root_certificates(root_store)
+                .with_no_client_auth();
+
+        if debug_info {
+            config.key_log = Arc::new(super::key_logger::MyKeyLogger);
+        }
+
+        Ok(Arc::new(config))
+    }
+
+    /// Convert a string to a [`ServerName`]
+    fn server_name_from_str(name: &str) -> Result<ServerName<'static>, TlsError> {
+        let dns = DnsName::try_from(name).map_err(|_| TlsError::InvalidDnsName)?;
+        Ok(ServerName::DnsName(dns.to_owned()))
+    }
+}
+
+/// The [`TlsConnection`] struct manages a TLS connection over a [`VsockStream`].
+/// It provides a way to manage all the TLS-related operations.
+pub struct TlsConnection {
+    conn: UnbufferedClientConnection,
+    sock: VsockStream,
+    in_buffer: TlsBuffer,
+    out_buffer: TlsBuffer,
+    status: ConnectionDetails,
+}
+
+impl TlsConnection {
+    /// Create a new [`TlsConnection`]
+    pub fn new(sock: VsockStream, conn: UnbufferedClientConnection) -> Self {
+        let in_buffer = TlsBuffer::new(IN_BUF_SIZE);
+        let out_buffer = TlsBuffer::new(OUT_BUF_SIZE);
+        let status = ConnectionDetails::new();
+        Self {
+            conn,
+            sock,
+            in_buffer,
+            out_buffer,
+            status,
+        }
+    }
+
+    /// Complete the TLS handshake
+    pub fn complete_handshake(&mut self) -> Result<(), SvsmError> {
+        while !self.status.handshake_complete && !self.status.connection_closed {
+            self.tls_state_machine_advance(TlsAction::Handshake)?;
+        }
+        Ok(())
+    }
+
+    /// Read a single TLS record and decrypt application data into the provided buffer
+    pub fn read_tls(&mut self, buf: &mut [u8]) -> Result<usize, SvsmError> {
+        let mut total_read = 0;
+        if self.status.connection_closed || self.status.peer_closed {
+            return Ok(0);
+        }
+        self.status.received_response = false; // reset for next read
+        while !self.status.received_response
+            && !self.status.connection_closed
+            && !self.status.peer_closed
+        {
+            self.tls_state_machine_advance(TlsAction::ReadRecord {
+                buffer: buf,
+                total_read: &mut total_read,
+            })?;
+        }
+        Ok(total_read)
+    }
+
+    /// Encrypt and send a single TLS record
+    pub fn write_tls(&mut self, data: &[u8]) -> Result<(), SvsmError> {
+        if self.status.connection_closed {
+            return Err(TlsError::ConnectionClosed.into());
+        }
+        self.tls_state_machine_advance(TlsAction::WriteRecord { buffer: data })?;
+        if !self.status.request_sent {
+            // should return 0?
+            return Err(TlsError::GenericError.into());
+        }
+        Ok(()) // should return buffer len?
+    }
+
+    /// Close the TLS connection
+    pub fn close_tls(&mut self) -> Result<(), SvsmError> {
+        while !self.status.connection_closed {
+            self.tls_state_machine_advance(TlsAction::CloseConnection)?;
+        }
+        Ok(())
+    }
+
+    /// Advance the TLS state machine based on the current connection state and the provided action
+    fn tls_state_machine_advance(&mut self, action: TlsAction<'_>) -> Result<(), SvsmError> {
+        // Process incoming TLS record and determine the next state
+        let UnbufferedStatus { discard, state } = self
+            .conn
+            .process_tls_records(self.in_buffer.curr_used_buf_as_mut());
+
+        match state.map_err(TlsError::from)? {
+            // ##################################################################
+            // Handshake states
+            // ##################################################################
+
+            // An handshake record needs to be encoded
+            ConnectionState::EncodeTlsData(mut encode_tls_data) => {
+                if TlsAction::Handshake != action {
+                    return Err(TlsError::UnexpectedState.into());
+                }
+
+                TlsConnection::prepare_handshake_record(
+                    &mut encode_tls_data,
+                    &mut self.out_buffer,
+                )?;
+                self.in_buffer.move_head(discard);
+            }
+
+            // The handshake record is ready to be transmitted
+            ConnectionState::TransmitTlsData(trasmit_tls_data) => {
+                if TlsAction::Handshake != action {
+                    return Err(TlsError::UnexpectedState.into());
+                }
+                TlsConnection::send_record_over_vsock(&mut self.sock, &mut self.out_buffer)?;
+                // Signal that the transmission is complete
+                trasmit_tls_data.done();
+                self.in_buffer.move_head(discard);
+                if !self.conn.is_handshaking() {
+                    self.status.handshake_complete = true;
+                }
+            }
+
+            // Waiting for a handshake record from the peer
+            ConnectionState::BlockedHandshake { .. } => {
+                if TlsAction::Handshake != action {
+                    return Err(TlsError::UnexpectedState.into());
+                }
+                self.in_buffer.move_head(discard);
+                self.recv_record_over_vsock()?;
+            }
+
+            // ##################################################################
+            // Application data states
+            // ##################################################################
+
+            // Ready to send application data, to close the connection, or to read data
+            ConnectionState::WriteTraffic(mut write_traffic) => {
+                if TlsAction::Handshake == action {
+                    return Err(TlsError::UnexpectedState.into());
+                }
+
+                if let TlsAction::WriteRecord { buffer } = action {
+                    TlsConnection::encrypt_data(&mut write_traffic, &mut self.out_buffer, buffer)?;
+                    TlsConnection::send_record_over_vsock(&mut self.sock, &mut self.out_buffer)?;
+                    self.status.request_sent = true;
+                    self.in_buffer.move_head(discard);
+                } else if TlsAction::CloseConnection == action && !self.status.our_side_closed {
+                    TlsConnection::prepare_queue_close_notify(
+                        &mut write_traffic,
+                        &mut self.out_buffer,
+                    )?;
+                    TlsConnection::send_record_over_vsock(&mut self.sock, &mut self.out_buffer)?;
+                    self.status.our_side_closed = true;
+                    self.in_buffer.move_head(discard);
+                } else {
+                    log::info!("Receiving record");
+                    self.in_buffer.move_head(discard);
+                    self.recv_record_over_vsock()?;
+                }
+            }
+
+            // Application data record ready to be read
+            ConnectionState::ReadTraffic(mut read_traffic) => {
+                let TlsAction::ReadRecord { buffer, total_read } = action else {
+                    return Err(TlsError::UnexpectedState.into());
+                };
+
+                let res = read_traffic
+                    .next_record()
+                    .ok_or(TlsError::GenericError)?
+                    .map_err(TlsError::from)?;
+
+                let mut total_discard = discard;
+
+                let AppDataRecord { discard, payload } = res;
+
+                total_discard += discard;
+
+                let payload_len = payload.len();
+                let to_copy = core::cmp::min(buffer.len(), payload_len);
+                buffer[..to_copy].copy_from_slice(&payload[..to_copy]);
+                self.in_buffer.move_head(total_discard);
+                self.status.received_response = true;
+                *total_read += to_copy;
+            }
+
+            // The peer sent a close_notify alert
+            ConnectionState::PeerClosed => {
+                log::info!("Peer closed the connection");
+                self.in_buffer.move_head(discard);
+                self.status.peer_closed = true;
+                // maybe call close_tls() here? What if I need to send more data?
+            }
+
+            // The connection is fully closed
+            ConnectionState::Closed => {
+                self.status.connection_closed = true;
+            }
+
+            _ => {
+                return Err(TlsError::UnexpectedState.into());
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Encrypt application data and store it in the out_buffer
+    fn encrypt_data(
+        write_traffic: &mut WriteTraffic<'_, ClientConnectionData>,
+        out_buffer: &mut TlsBuffer,
+        data: &[u8],
+    ) -> Result<(), TlsError> {
+        let bytes_written = write_traffic.encrypt(data, out_buffer.remaining_buf_as_mut())?;
+        out_buffer.advance_used(bytes_written)?;
+
+        Ok(())
+    }
+
+    /// Prepare a close_notify alert to be sent over the network. From this point on, no more data can be sent.
+    fn prepare_queue_close_notify(
+        write_traffic: &mut WriteTraffic<'_, ClientConnectionData>,
+        out_buffer: &mut TlsBuffer,
+    ) -> Result<(), TlsError> {
+        let bytes_written = write_traffic.queue_close_notify(out_buffer.remaining_buf_as_mut())?;
+        out_buffer.advance_used(bytes_written)?;
+        Ok(())
+    }
+
+    /// Prepare a TLS handshake record to be sent over the network based on the current handshake state
+    fn prepare_handshake_record(
+        encode_tls_data: &mut EncodeTlsData<'_, ClientConnectionData>,
+        out_buffer: &mut TlsBuffer,
+    ) -> Result<(), TlsError> {
+        let bytes_written = encode_tls_data.encode(out_buffer.remaining_buf_as_mut())?;
+        out_buffer.advance_used(bytes_written)?;
+        Ok(())
+    }
+
+    /// Send the contents of the out_buffer over the [`VsockStream`] and reset the buffer
+    fn send_record_over_vsock(
+        sock: &mut VsockStream,
+        out_buffer: &mut TlsBuffer,
+    ) -> Result<(), SvsmError> {
+        sock.write(out_buffer.curr_used_buf_as_ref())?;
+        out_buffer.reset_used();
+        Ok(())
+    }
+
+    /// Receive a TLS record from the [`VsockStream`] and store it in the in_buffer
+    fn recv_record_over_vsock(&mut self) -> Result<(), SvsmError> {
+        // First read the TLS record header to determine the payload length
+        // Then read the payload based on the length specified in the header
+
+        self.in_buffer.ensure_space(HEADER_LEN)?;
+
+        let read_bytes = self
+            .sock
+            .read(self.in_buffer.mutable_slice_from_remaining(HEADER_LEN)?)?;
+
+        if read_bytes != HEADER_LEN {
+            return Err(TlsError::IncompleteRead.into());
+        }
+
+        let payload_len = self.in_buffer.extract_record_len_from_current_position()?;
+        self.in_buffer.advance_used(HEADER_LEN)?;
+
+        self.in_buffer.ensure_space(payload_len)?;
+
+        let read_bytes = self
+            .sock
+            .read(self.in_buffer.mutable_slice_from_remaining(payload_len)?)?;
+
+        if read_bytes != payload_len {
+            return Err(TlsError::IncompleteRead.into());
+        }
+
+        self.in_buffer.advance_used(payload_len)?;
+
+        Ok(())
+    }
+}
+
+impl core::fmt::Debug for TlsConnection {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("TlsConnection")
+            .field("in_buffer", &self.in_buffer)
+            .field("out_buffer", &self.out_buffer)
+            .field("sock", &self.sock)
+            .field("status", &self.status)
+            .field("conn", &"UnbufferedClientConnection")
+            .finish()
+    }
+}
+
+impl Drop for TlsConnection {
+    fn drop(&mut self) {
+        // fixme: Should I move the close logic here?
+        // if !self.status.connection_closed {
+        //     if let Err(e) = self.close_tls() {
+        //         log::error!("Error closing TLS connection: {:?}", e);
+        //    }
+        //}
+        if let Err(e) = self.sock.close() {
+            log::error!("Error closing VsockStream: {:?}", e);
+        }
+    }
+}
+
+/// Represents the possible actions that can be performed in the TLS state machine.
+#[derive(PartialEq)]
+enum TlsAction<'a> {
+    Handshake,
+    ReadRecord {
+        buffer: &'a mut [u8],
+        total_read: &'a mut usize,
+    },
+    WriteRecord {
+        buffer: &'a [u8],
+    },
+    CloseConnection,
+}
+
+/// Internal struct to track the state of the TLS connection
+#[derive(Debug)]
+struct ConnectionDetails {
+    handshake_complete: bool,
+    request_sent: bool,
+    received_response: bool,
+    peer_closed: bool,
+    our_side_closed: bool,
+    connection_closed: bool,
+}
+
+impl ConnectionDetails {
+    /// Create a new [`ConnectionDetails`] instance with default values
+    fn new() -> Self {
+        Self {
+            handshake_complete: false,
+            request_sent: false,
+            received_response: false,
+            peer_closed: false,
+            our_side_closed: false,
+            connection_closed: false,
+        }
+    }
+}

--- a/kernel/src/tls/constant.rs
+++ b/kernel/src/tls/constant.rs
@@ -1,0 +1,8 @@
+// Constants for TLS management
+pub const HEADER_LEN: usize = 5;
+pub const FIRST_LEN_BYTE_POS: usize = 4;
+pub const SECOND_LEN_BYTE_POS: usize = 3;
+const CONTENT_TYPE: usize = 1; // TLS ContentType field size in bytes
+const AEAD_OVERHEAD: usize = 16 + CONTENT_TYPE; // Bytes added by AEAD encryption
+pub const IN_BUF_SIZE: usize = 16 * 1024 + AEAD_OVERHEAD + HEADER_LEN;
+pub const OUT_BUF_SIZE: usize = 1024;

--- a/kernel/src/tls/crypto_provider/aead.rs
+++ b/kernel/src/tls/crypto_provider/aead.rs
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2016 Joseph Birr-Pixton <jpixton@gmail.com>
+//
+// Derived from the crypto-provider example in rustls (https://github.com/rustls/rustls/tree/main/provider-example)
+
+extern crate alloc;
+use alloc::boxed::Box;
+
+use rustls::{
+    crypto::cipher::{
+        make_tls13_aad, AeadKey, BorrowedPayload, InboundOpaqueMessage, InboundPlainMessage, Iv,
+        MessageDecrypter, MessageEncrypter, Nonce, OutboundOpaqueMessage, OutboundPlainMessage,
+        PrefixedPayload, Tls13AeadAlgorithm, UnsupportedOperationError,
+    },
+    ConnectionTrafficSecrets, ContentType, ProtocolVersion,
+};
+
+use aes_gcm::{
+    aead::{AeadInPlace, Buffer, Result as AeadResult},
+    KeyInit, KeySizeUser,
+};
+
+pub(crate) struct Aes128Gcm;
+
+impl Tls13AeadAlgorithm for Aes128Gcm {
+    fn encrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageEncrypter> {
+        Box::new(Tls13Cipher(
+            aes_gcm::Aes128Gcm::new_from_slice(key.as_ref()).unwrap(),
+            iv,
+        ))
+    }
+
+    fn decrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageDecrypter> {
+        Box::new(Tls13Cipher(
+            aes_gcm::Aes128Gcm::new_from_slice(key.as_ref()).unwrap(),
+            iv,
+        ))
+    }
+
+    fn key_len(&self) -> usize {
+        aes_gcm::Aes128Gcm::key_size()
+    }
+
+    fn extract_keys(
+        &self,
+        key: AeadKey,
+        iv: Iv,
+    ) -> Result<ConnectionTrafficSecrets, UnsupportedOperationError> {
+        Ok(ConnectionTrafficSecrets::Aes128Gcm { key, iv })
+    }
+}
+
+const AES_GCM_OVERHEAD: usize = 16;
+struct Tls13Cipher(aes_gcm::Aes128Gcm, Iv);
+
+impl MessageEncrypter for Tls13Cipher {
+    fn encrypt(
+        &mut self,
+        msg: OutboundPlainMessage<'_>,
+        seq: u64,
+    ) -> Result<OutboundOpaqueMessage, rustls::Error> {
+        let total_len = self.encrypted_payload_len(msg.payload.len());
+        let mut payload = PrefixedPayload::with_capacity(total_len);
+
+        payload.extend_from_chunks(&msg.payload);
+        payload.extend_from_slice(&msg.typ.to_array());
+
+        let nonce = Nonce::new(&self.1, seq);
+        let nonce = aes_gcm::Nonce::from(nonce.0);
+
+        let aad = make_tls13_aad(total_len);
+
+        self.0
+            .encrypt_in_place(&nonce, &aad, &mut EncryptBufferAdapter(&mut payload))
+            .map_err(|_| rustls::Error::EncryptError)
+            .map(|_| {
+                OutboundOpaqueMessage::new(
+                    ContentType::ApplicationData,
+                    ProtocolVersion::TLSv1_2,
+                    payload,
+                )
+            })
+    }
+
+    fn encrypted_payload_len(&self, payload_len: usize) -> usize {
+        payload_len + AES_GCM_OVERHEAD + 1
+    }
+}
+
+impl MessageDecrypter for Tls13Cipher {
+    fn decrypt<'a>(
+        &mut self,
+        mut msg: InboundOpaqueMessage<'a>,
+        seq: u64,
+    ) -> Result<InboundPlainMessage<'a>, rustls::Error> {
+        let payload = &mut msg.payload;
+
+        let nonce = Nonce::new(&self.1, seq);
+        let nonce = aes_gcm::Nonce::from(nonce.0);
+
+        let aad = make_tls13_aad(payload.len());
+
+        self.0
+            .decrypt_in_place(&nonce, &aad, &mut DecryptBufferAdapter(payload))
+            .map_err(|_| rustls::Error::DecryptError)?;
+
+        msg.into_tls13_unpadded_message()
+    }
+}
+
+struct EncryptBufferAdapter<'a>(&'a mut PrefixedPayload);
+
+impl AsRef<[u8]> for EncryptBufferAdapter<'_> {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl AsMut<[u8]> for EncryptBufferAdapter<'_> {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.0.as_mut()
+    }
+}
+
+impl Buffer for EncryptBufferAdapter<'_> {
+    fn extend_from_slice(&mut self, other: &[u8]) -> AeadResult<()> {
+        self.0.extend_from_slice(other);
+        Ok(())
+    }
+
+    fn truncate(&mut self, len: usize) {
+        self.0.truncate(len)
+    }
+}
+
+struct DecryptBufferAdapter<'a, 'p>(&'a mut BorrowedPayload<'p>);
+
+impl AsRef<[u8]> for DecryptBufferAdapter<'_, '_> {
+    fn as_ref(&self) -> &[u8] {
+        self.0
+    }
+}
+
+impl AsMut<[u8]> for DecryptBufferAdapter<'_, '_> {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.0
+    }
+}
+
+impl Buffer for DecryptBufferAdapter<'_, '_> {
+    fn extend_from_slice(&mut self, _: &[u8]) -> AeadResult<()> {
+        unreachable!("not used by `AeadInPlace::decrypt_in_place`")
+    }
+
+    fn truncate(&mut self, len: usize) {
+        self.0.truncate(len)
+    }
+}

--- a/kernel/src/tls/crypto_provider/hash.rs
+++ b/kernel/src/tls/crypto_provider/hash.rs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2016 Joseph Birr-Pixton <jpixton@gmail.com>
+//
+// Derived from the crypto-provider example in rustls (https://github.com/rustls/rustls/tree/main/provider-example)
+
+extern crate alloc;
+use alloc::boxed::Box;
+
+use rustls::crypto::hash;
+use sha2::Digest;
+
+pub(crate) struct Sha256;
+
+impl hash::Hash for Sha256 {
+    fn start(&self) -> Box<dyn hash::Context> {
+        Box::new(Sha256Context(sha2::Sha256::new()))
+    }
+
+    fn hash(&self, data: &[u8]) -> hash::Output {
+        hash::Output::new(&sha2::Sha256::digest(data)[..])
+    }
+
+    fn algorithm(&self) -> hash::HashAlgorithm {
+        hash::HashAlgorithm::SHA256
+    }
+
+    fn output_len(&self) -> usize {
+        32
+    }
+}
+
+struct Sha256Context(sha2::Sha256);
+
+impl hash::Context for Sha256Context {
+    fn fork_finish(&self) -> hash::Output {
+        hash::Output::new(&self.0.clone().finalize()[..])
+    }
+
+    fn fork(&self) -> Box<dyn hash::Context> {
+        Box::new(Self(self.0.clone()))
+    }
+
+    fn finish(self: Box<Self>) -> hash::Output {
+        hash::Output::new(&self.0.finalize()[..])
+    }
+
+    fn update(&mut self, data: &[u8]) {
+        self.0.update(data);
+    }
+}

--- a/kernel/src/tls/crypto_provider/hmac.rs
+++ b/kernel/src/tls/crypto_provider/hmac.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2016 Joseph Birr-Pixton <jpixton@gmail.com>
+//
+// Derived from the crypto-provider example in rustls (https://github.com/rustls/rustls/tree/main/provider-example)
+
+extern crate alloc;
+use alloc::boxed::Box;
+
+use hmac::{Hmac, Mac};
+use rustls::crypto;
+use sha2::{Digest, Sha256};
+
+pub(crate) struct Sha256Hmac;
+
+impl crypto::hmac::Hmac for Sha256Hmac {
+    fn with_key(&self, key: &[u8]) -> Box<dyn crypto::hmac::Key> {
+        Box::new(Sha256HmacKey(Hmac::<Sha256>::new_from_slice(key).unwrap()))
+    }
+
+    fn hash_output_len(&self) -> usize {
+        Sha256::output_size()
+    }
+}
+
+struct Sha256HmacKey(Hmac<Sha256>);
+
+impl crypto::hmac::Key for Sha256HmacKey {
+    fn sign_concat(&self, first: &[u8], middle: &[&[u8]], last: &[u8]) -> crypto::hmac::Tag {
+        let mut ctx = self.0.clone();
+        ctx.update(first);
+        for m in middle {
+            ctx.update(m);
+        }
+        ctx.update(last);
+        crypto::hmac::Tag::new(&ctx.finalize().into_bytes()[..])
+    }
+
+    fn tag_len(&self) -> usize {
+        Sha256::output_size()
+    }
+}

--- a/kernel/src/tls/crypto_provider/kx.rs
+++ b/kernel/src/tls/crypto_provider/kx.rs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2016 Joseph Birr-Pixton <jpixton@gmail.com>
+//
+// Derived from the crypto-provider example in rustls (https://github.com/rustls/rustls/tree/main/provider-example)
+
+extern crate alloc;
+use alloc::boxed::Box;
+
+use crypto::SupportedKxGroup;
+use ecdsa::signature::rand_core;
+use rustls::crypto;
+
+pub(crate) struct KeyExchange {
+    priv_key: x25519_dalek::EphemeralSecret,
+    pub_key: x25519_dalek::PublicKey,
+}
+
+impl crypto::ActiveKeyExchange for KeyExchange {
+    fn complete(self: Box<Self>, peer: &[u8]) -> Result<crypto::SharedSecret, rustls::Error> {
+        let peer_array: [u8; 32] = peer
+            .try_into()
+            .map_err(|_| rustls::Error::from(rustls::PeerMisbehaved::InvalidKeyShare))?;
+        let their_pub = x25519_dalek::PublicKey::from(peer_array);
+        let shared_secret = self.priv_key.diffie_hellman(&their_pub);
+        Ok(crypto::SharedSecret::from(&shared_secret.as_bytes()[..]))
+    }
+
+    fn pub_key(&self) -> &[u8] {
+        self.pub_key.as_bytes()
+    }
+
+    fn group(&self) -> rustls::NamedGroup {
+        X25519.name()
+    }
+}
+
+pub(crate) const ALL_KX_GROUPS: &[&dyn SupportedKxGroup] = &[&X25519];
+
+#[derive(Debug)]
+pub(crate) struct X25519;
+
+impl SupportedKxGroup for X25519 {
+    fn start(&self) -> Result<Box<dyn crypto::ActiveKeyExchange>, rustls::Error> {
+        let priv_key = x25519_dalek::EphemeralSecret::random_from_rng(rand_core::OsRng);
+        Ok(Box::new(KeyExchange {
+            pub_key: (&priv_key).into(),
+            priv_key,
+        }))
+    }
+
+    fn name(&self) -> rustls::NamedGroup {
+        rustls::NamedGroup::X25519
+    }
+}

--- a/kernel/src/tls/crypto_provider/mod.rs
+++ b/kernel/src/tls/crypto_provider/mod.rs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2016 Joseph Birr-Pixton <jpixton@gmail.com>
+//
+// Derived from the crypto-provider example in rustls (https://github.com/rustls/rustls/tree/main/provider-example)
+
+extern crate alloc;
+use alloc::sync::Arc;
+use rustls::crypto::CryptoProvider;
+use rustls::pki_types::PrivateKeyDer;
+
+mod aead;
+mod hash;
+mod hmac;
+mod kx;
+mod sign;
+mod verify;
+
+/// Returns a `CryptoProvider` that supports a limited set of cryptographic operations.
+pub fn provider() -> CryptoProvider {
+    CryptoProvider {
+        cipher_suites: ALL_CIPHER_SUITES.to_vec(),
+        kx_groups: kx::ALL_KX_GROUPS.to_vec(),
+        signature_verification_algorithms: verify::ALGORITHMS,
+        secure_random: &Provider,
+        key_provider: &Provider,
+    }
+}
+
+// The following is a RNG based on the cocoon_tpm_crypto crate. There is also a better version in
+// https://github.com/coconut-svsm/svsm/pull/806
+// For the moment, we use the OsRng from rand_core as a placeholder.
+// use cocoon_tpm_crypto::rng::ChainedRng;
+// use cocoon_tpm_crypto::rng::{test_rng, RngCore, X86RdSeedRng};
+// use cocoon_tpm_crypto::EmptyCryptoIoSlices;
+// use cocoon_tpm_utils_common::io_slices::{self, IoSlicesIterCommon};
+
+// #[derive(Debug)]
+// struct Provider;
+
+// impl rustls::crypto::SecureRandom for Provider {
+//     fn fill(&self, bytes: &mut [u8]) -> Result<(), rustls::crypto::GetRandomFailed> {
+//         let parent_rng =
+//             X86RdSeedRng::instantiate().map_err(|_| rustls::crypto::GetRandomFailed)?;
+//         let child_rng = test_rng();
+
+//         let mut chained_rng = ChainedRng::chain(parent_rng, child_rng);
+
+//         chained_rng
+//             .generate(
+//                 io_slices::SingletonIoSliceMut::new(bytes).map_infallible_err(),
+//                 None::<EmptyCryptoIoSlices>,
+//             )
+//             .map_err(|_| rustls::crypto::GetRandomFailed)
+//     }
+// }
+
+#[derive(Debug)]
+struct Provider;
+
+impl rustls::crypto::SecureRandom for Provider {
+    fn fill(&self, bytes: &mut [u8]) -> Result<(), rustls::crypto::GetRandomFailed> {
+        use rand_core::RngCore;
+        rand_core::OsRng
+            .try_fill_bytes(bytes)
+            .map_err(|_| rustls::crypto::GetRandomFailed)
+    }
+}
+
+impl rustls::crypto::KeyProvider for Provider {
+    fn load_private_key(
+        &self,
+        key_der: PrivateKeyDer<'static>,
+    ) -> Result<Arc<dyn rustls::sign::SigningKey>, rustls::Error> {
+        Ok(Arc::new(
+            sign::EcdsaSigningKeyP256::try_from(key_der)
+                .map_err(|err| rustls::Error::General(alloc::format!("{}", err)))?,
+        ))
+    }
+}
+
+static ALL_CIPHER_SUITES: &[rustls::SupportedCipherSuite] = &[rustls::SupportedCipherSuite::Tls13(
+    &rustls::Tls13CipherSuite {
+        common: rustls::crypto::CipherSuiteCommon {
+            suite: rustls::CipherSuite::TLS13_AES_128_GCM_SHA256,
+            hash_provider: &hash::Sha256,
+            confidentiality_limit: u64::MAX,
+        },
+        //protocol_version: rustls::version::TLS13_VERSION,
+        hkdf_provider: &rustls::crypto::tls13::HkdfUsingHmac(&hmac::Sha256Hmac),
+        aead_alg: &aead::Aes128Gcm,
+        quic: None,
+    },
+)];

--- a/kernel/src/tls/crypto_provider/sign.rs
+++ b/kernel/src/tls/crypto_provider/sign.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2016 Joseph Birr-Pixton <jpixton@gmail.com>
+//
+// Derived from the crypto-provider example in rustls (https://github.com/rustls/rustls/tree/main/provider-example)
+
+extern crate alloc;
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+
+use pkcs8::{DecodePrivateKey, EncodePublicKey};
+use rustls::pki_types::{PrivateKeyDer, SubjectPublicKeyInfoDer};
+use rustls::sign::{Signer, SigningKey};
+use rustls::{SignatureAlgorithm, SignatureScheme};
+use signature::{RandomizedSigner, SignatureEncoding};
+
+#[derive(Clone, Debug)]
+pub(crate) struct EcdsaSigningKeyP256 {
+    key: Arc<p256::ecdsa::SigningKey>,
+    scheme: SignatureScheme,
+}
+
+impl TryFrom<PrivateKeyDer<'_>> for EcdsaSigningKeyP256 {
+    type Error = pkcs8::Error;
+
+    fn try_from(value: PrivateKeyDer<'_>) -> Result<Self, Self::Error> {
+        match value {
+            PrivateKeyDer::Pkcs8(der) => {
+                p256::ecdsa::SigningKey::from_pkcs8_der(der.secret_pkcs8_der()).map(|kp| Self {
+                    key: Arc::new(kp),
+                    scheme: SignatureScheme::ECDSA_NISTP256_SHA256,
+                })
+            }
+            _ => panic!("unsupported private key format"),
+        }
+    }
+}
+
+impl SigningKey for EcdsaSigningKeyP256 {
+    fn choose_scheme(&self, offered: &[SignatureScheme]) -> Option<Box<dyn Signer>> {
+        if offered.contains(&self.scheme) {
+            Some(Box::new(self.clone()))
+        } else {
+            None
+        }
+    }
+
+    fn public_key(&self) -> Option<SubjectPublicKeyInfoDer<'_>> {
+        Some(SubjectPublicKeyInfoDer::from(
+            self.key
+                .verifying_key()
+                .to_public_key_der()
+                .ok()?
+                .into_vec(),
+        ))
+    }
+
+    fn algorithm(&self) -> SignatureAlgorithm {
+        SignatureAlgorithm::ECDSA
+    }
+}
+
+impl Signer for EcdsaSigningKeyP256 {
+    fn sign(&self, message: &[u8]) -> Result<Vec<u8>, rustls::Error> {
+        self.key
+            .try_sign_with_rng(&mut rand_core::OsRng, message)
+            .map_err(|_| rustls::Error::General("signing failed".into()))
+            .map(|sig: p256::ecdsa::DerSignature| sig.to_vec())
+    }
+
+    fn scheme(&self) -> SignatureScheme {
+        self.scheme
+    }
+}

--- a/kernel/src/tls/crypto_provider/verify.rs
+++ b/kernel/src/tls/crypto_provider/verify.rs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2016 Joseph Birr-Pixton <jpixton@gmail.com>
+//
+// Derived from the crypto-provider example in rustls (https://github.com/rustls/rustls/tree/main/provider-example)
+
+use der::Reader;
+use rsa::signature::Verifier;
+use rsa::{pkcs1v15, pss, BigUint, RsaPublicKey};
+use rustls::crypto::WebPkiSupportedAlgorithms;
+use rustls::pki_types::{
+    alg_id, AlgorithmIdentifier, InvalidSignature, SignatureVerificationAlgorithm,
+};
+use rustls::SignatureScheme;
+
+pub(crate) static ALGORITHMS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
+    all: &[RSA_PSS_SHA256, RSA_PKCS1_SHA256],
+    mapping: &[
+        (SignatureScheme::RSA_PSS_SHA256, &[RSA_PSS_SHA256]),
+        (SignatureScheme::RSA_PKCS1_SHA256, &[RSA_PKCS1_SHA256]),
+    ],
+};
+
+static RSA_PSS_SHA256: &dyn SignatureVerificationAlgorithm = &RsaPssSha256Verify;
+static RSA_PKCS1_SHA256: &dyn SignatureVerificationAlgorithm = &RsaPkcs1Sha256Verify;
+
+#[derive(Debug)]
+struct RsaPssSha256Verify;
+
+impl SignatureVerificationAlgorithm for RsaPssSha256Verify {
+    fn public_key_alg_id(&self) -> AlgorithmIdentifier {
+        alg_id::RSA_ENCRYPTION
+    }
+
+    fn signature_alg_id(&self) -> AlgorithmIdentifier {
+        alg_id::RSA_PSS_SHA256
+    }
+
+    fn verify_signature(
+        &self,
+        public_key: &[u8],
+        message: &[u8],
+        signature: &[u8],
+    ) -> Result<(), InvalidSignature> {
+        let public_key = decode_spki_spk(public_key)?;
+
+        let signature = pss::Signature::try_from(signature).map_err(|_| InvalidSignature)?;
+
+        pss::VerifyingKey::<sha2::Sha256>::new(public_key)
+            .verify(message, &signature)
+            .map_err(|_| InvalidSignature)
+    }
+}
+
+#[derive(Debug)]
+struct RsaPkcs1Sha256Verify;
+
+impl SignatureVerificationAlgorithm for RsaPkcs1Sha256Verify {
+    fn public_key_alg_id(&self) -> AlgorithmIdentifier {
+        alg_id::RSA_ENCRYPTION
+    }
+
+    fn signature_alg_id(&self) -> AlgorithmIdentifier {
+        alg_id::RSA_PKCS1_SHA256
+    }
+
+    fn verify_signature(
+        &self,
+        public_key: &[u8],
+        message: &[u8],
+        signature: &[u8],
+    ) -> Result<(), InvalidSignature> {
+        let public_key = decode_spki_spk(public_key)?;
+
+        let signature = pkcs1v15::Signature::try_from(signature).map_err(|_| InvalidSignature)?;
+
+        pkcs1v15::VerifyingKey::<sha2::Sha256>::new(public_key)
+            .verify(message, &signature)
+            .map_err(|_| InvalidSignature)
+    }
+}
+
+fn decode_spki_spk(spki_spk: &[u8]) -> Result<RsaPublicKey, InvalidSignature> {
+    // public_key: unfortunately this is not a whole SPKI, but just the key material.
+    // decode the two integers manually.
+    let mut reader = der::SliceReader::new(spki_spk).map_err(|_| InvalidSignature)?;
+    let ne: [der::asn1::UintRef<'_>; 2] = reader.decode().map_err(|_| InvalidSignature)?;
+
+    RsaPublicKey::new(
+        BigUint::from_bytes_be(ne[0].as_bytes()),
+        BigUint::from_bytes_be(ne[1].as_bytes()),
+    )
+    .map_err(|_| InvalidSignature)
+}

--- a/kernel/src/tls/error.rs
+++ b/kernel/src/tls/error.rs
@@ -1,0 +1,74 @@
+/// Errors specific to TLS operations
+#[derive(Clone, Copy, Debug)]
+pub enum TlsError {
+    HandshakeFailed,
+    InvalidMessage,
+    InvalidCertificate,
+    EncryptError,
+    DecryptError,
+    NoCertificates,
+    UnsupportedNameType,
+    GenericError,
+    ConnectionClosed,
+    InvalidDnsName,
+    EncodeError,
+    EarlyDataError,
+    FailedToGetRandomBytes,
+    MaxIterationsReached,
+    HandshakeNotComplete,
+    UnexpectedState,
+    BufferTooSmall,
+    IncompleteRead,
+    PeerClosed,
+    RequestAlreadySent,
+    ConnectionAlreadyClosed,
+}
+
+impl From<rustls::pki_types::InvalidDnsNameError> for TlsError {
+    fn from(_err: rustls::pki_types::InvalidDnsNameError) -> Self {
+        TlsError::InvalidDnsName
+    }
+}
+
+impl From<rustls::Error> for TlsError {
+    fn from(err: rustls::Error) -> Self {
+        use rustls::Error::*;
+        log::info!("Error from rustls: {:?}", err);
+        match err {
+            InappropriateMessage { .. } => TlsError::InvalidMessage,
+            InappropriateHandshakeMessage { .. } => TlsError::HandshakeFailed,
+            InvalidEncryptedClientHello(_) => TlsError::HandshakeFailed,
+            InvalidMessage(_) => TlsError::InvalidMessage,
+            NoCertificatesPresented => TlsError::NoCertificates,
+            UnsupportedNameType => TlsError::UnsupportedNameType,
+            DecryptError => TlsError::DecryptError,
+            EncryptError => TlsError::EncryptError,
+            PeerIncompatible(_) | PeerMisbehaved(_) | HandshakeNotComplete => {
+                TlsError::HandshakeFailed
+            }
+            InvalidCertificate(_) | InvalidCertRevocationList(_) => TlsError::InvalidCertificate,
+            General(_) => TlsError::GenericError,
+            FailedToGetCurrentTime => TlsError::GenericError,
+            FailedToGetRandomBytes => TlsError::FailedToGetRandomBytes,
+            PeerSentOversizedRecord | NoApplicationProtocol | BadMaxFragmentSize => {
+                TlsError::HandshakeFailed
+            }
+            AlertReceived(_) => TlsError::ConnectionClosed,
+            InconsistentKeys(_) => TlsError::HandshakeFailed,
+            Other(_) => TlsError::GenericError,
+            _ => TlsError::GenericError,
+        }
+    }
+}
+
+impl From<rustls::unbuffered::EncodeError> for TlsError {
+    fn from(_err: rustls::unbuffered::EncodeError) -> Self {
+        TlsError::EncodeError
+    }
+}
+
+impl From<rustls::unbuffered::EncryptError> for TlsError {
+    fn from(_err: rustls::unbuffered::EncryptError) -> Self {
+        TlsError::EncryptError
+    }
+}

--- a/kernel/src/tls/examples.rs
+++ b/kernel/src/tls/examples.rs
@@ -1,0 +1,172 @@
+// ########################################################
+// # Example functions to test the TLS connection
+// ########################################################
+
+extern crate alloc;
+
+use crate::error::SvsmError;
+use crate::vsock::virtio_vsock::VsockStream;
+
+use super::constant::IN_BUF_SIZE;
+
+const LOCAL_PORT: u32 = 1234;
+const REMOTE_PORT: u32 = 12345;
+const REMOTE_CID: u64 = 2;
+const SERVER_DNS: &str = "localhost";
+
+use super::connection::{TlsClient, TlsConnection};
+
+/// Test function to perform a simple HTTPS GET request over TLS
+pub fn test_https() {
+    log::info!("Opening TLS...");
+
+    let mut tls_connection = TlsClient::new(false)
+        .connect(
+            VsockStream::connect(LOCAL_PORT, REMOTE_PORT, REMOTE_CID)
+                .expect("Failed to connect to VsockStream"),
+            SERVER_DNS,
+        )
+        .expect("Failed to create TLS connection");
+
+    tls_connection
+        .complete_handshake()
+        .expect("Failed to complete TLS handshake");
+
+    let http_request =
+        "GET /hello.html HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n".as_bytes();
+
+    log::info!("########################################################");
+    log::info!("Sending HTTP request");
+    log::info!("########################################################");
+    tls_connection
+        .write_tls(http_request)
+        .expect("Failed to write application data over TLS");
+
+    log::info!("########################################################");
+    log::info!("Receiving HTTP response");
+    log::info!("########################################################");
+    let mut data_from_server = alloc::vec![0u8; IN_BUF_SIZE * 3]; // this is arbitrary
+
+    let total_len = read_command(&mut tls_connection, &mut data_from_server)
+        .expect("Failed to read application data over TLS");
+
+    let response = core::str::from_utf8(&data_from_server).unwrap_or("<Invalid UTF-8>");
+    log::info!("Total length: {}\n Response: \n {}", total_len, response);
+
+    log::info!("########################################################");
+    log::info!("Closing TLS connection");
+    log::info!("########################################################");
+    tls_connection
+        .close_tls()
+        .expect("Failed to close TLS connection");
+
+    log::info!("TLS conversation completed.");
+}
+
+/// Test function to interact with a command server over TLS
+/// The server is expected to send commands and wait for responses.
+/// The interaction continues until an "EXIT" command is received.  
+/// The server is expected to close the connection after sending the "EXIT" command.
+pub fn test_command_server() {
+    log::info!("Opening TLS...");
+
+    let mut tls_connection = TlsClient::new(false)
+        .connect(
+            VsockStream::connect(LOCAL_PORT, REMOTE_PORT, REMOTE_CID)
+                .expect("Failed to connect to VsockStream"),
+            SERVER_DNS,
+        )
+        .expect("Failed to create TLS connection");
+
+    log::info!("########################################################");
+    log::info!("Completing TLS handshake");
+    log::info!("########################################################");
+    tls_connection
+        .complete_handshake()
+        .expect("Failed to complete TLS handshake");
+
+    log::info!("########################################################");
+    log::info!("Entering command server read loop");
+    log::info!("########################################################");
+
+    let mut data_from_server = alloc::vec![0u8; IN_BUF_SIZE * 3];
+
+    loop {
+        log::info!("########################################################");
+        log::info!("Waiting for command server input");
+        log::info!("########################################################");
+
+        let total_len = read_command(&mut tls_connection, &mut data_from_server)
+            .expect("Failed to read application data over TLS");
+
+        if total_len == 0 {
+            log::info!("Peer closed the connection, exiting read loop");
+            break;
+        }
+
+        let response =
+            core::str::from_utf8(&data_from_server[..total_len]).unwrap_or("<Invalid UTF-8>");
+
+        log::info!("Received {} bytes:\n{}", total_len, response);
+        log::info!("########################################################");
+        log::info!("Sending response to command server");
+        log::info!("########################################################");
+
+        let response_message = b"Message received\n";
+        tls_connection
+            .write_tls(response_message)
+            .expect("Failed to write application data over TLS");
+
+        if response.contains("EXIT") {
+            log::info!("Received EXIT command, exiting read loop");
+            break;
+        } else {
+            log::info!("Received command: {}\n Continue", response);
+        }
+    }
+
+    log::info!("########################################################");
+    log::info!("Closing TLS connection");
+    log::info!("########################################################");
+    tls_connection
+        .close_tls()
+        .expect("Failed to close TLS connection");
+    log::info!("TLS conversation completed.");
+}
+
+fn read_command(tls_connection: &mut TlsConnection, buf: &mut [u8]) -> Result<usize, SvsmError> {
+    // read application data record from the server
+    // for the moment just one read
+    let mut iter_count = 1;
+    log::info!("Initial read iteration");
+    let mut total_read = 0;
+    let partial_read = tls_connection.read_tls(&mut buf[total_read..])?;
+
+    if partial_read == 0 {
+        log::info!("No data received from server");
+        return Ok(0);
+    }
+
+    total_read += partial_read;
+
+    // extract content-length from the HTTP response header
+    // for the moment just arbitrary number of reads
+    // what if the response header is not complete?
+
+    while iter_count < 1 {
+        // should use content-length to determine when to stop
+        log::info!("Read iteration {}", iter_count);
+        tls_connection
+            .read_tls(&mut buf[total_read..])
+            .map(|len| {
+                if len == 0 {
+                    return;
+                }
+                total_read += len;
+            })
+            .expect("Failed to read application data over TLS");
+        iter_count += 1;
+    }
+
+    Ok(total_read)
+}

--- a/kernel/src/tls/key_logger.rs
+++ b/kernel/src/tls/key_logger.rs
@@ -1,0 +1,29 @@
+extern crate alloc;
+use alloc::string::String;
+use rustls::KeyLog;
+
+/// A simple implementation of the [`KeyLog`] trait that logs TLS secrets using the log crate
+#[derive(Debug)]
+pub struct MyKeyLogger;
+
+impl KeyLog for MyKeyLogger {
+    /// Logs the TLS secrets.
+    fn log(&self, label: &str, client_random: &[u8], secret: &[u8]) {
+        fn hex(bytes: &[u8]) -> String {
+            let mut s = String::new();
+            for b in bytes {
+                s.push_str(&alloc::format!("{:02x}", b));
+            }
+            s
+        }
+
+        let msg = alloc::format!(
+            "{label} {client_random} {secret}",
+            label = label,
+            client_random = hex(client_random),
+            secret = hex(secret)
+        );
+
+        log::info!("KeyLog: {msg}");
+    }
+}

--- a/kernel/src/tls/mod.rs
+++ b/kernel/src/tls/mod.rs
@@ -8,4 +8,5 @@ mod time_provider;
 // Public modules for TLS implementation
 pub mod connection;
 pub mod error;
+pub mod examples;
 pub mod random;

--- a/kernel/src/tls/mod.rs
+++ b/kernel/src/tls/mod.rs
@@ -1,0 +1,11 @@
+// Private modules for TLS implementation
+mod buffer;
+mod constant;
+mod crypto_provider;
+mod key_logger;
+mod time_provider;
+
+// Public modules for TLS implementation
+pub mod connection;
+pub mod error;
+pub mod random;

--- a/kernel/src/tls/random.rs
+++ b/kernel/src/tls/random.rs
@@ -1,0 +1,40 @@
+use core::arch::asm;
+use getrandom::Error as GetRandomError;
+
+/// A custom implementation of a random number generator using the `rdrand` instruction on x86_64.
+/// This is a placeholder implementation.
+pub fn custom_getrandom(buf: &mut [u8]) -> Result<(), GetRandomError> {
+    for chunk in buf.chunks_mut(8) {
+        let mut rnd: u64;
+        let mut ok: u8;
+        let mut tries = 0;
+
+        loop {
+            // SAFETY: `rdrand` is safe to call on x86_64 processors that support it.
+            unsafe {
+                asm!(
+                    "rdrand {0}",
+                    "setc {1}",
+                    out(reg) rnd,
+                    out(reg_byte) ok,
+                );
+            }
+
+            if ok == 1 {
+                break;
+            }
+
+            tries += 1;
+            if tries > 10 {
+                return Err(GetRandomError::FAILED_RDRAND);
+            }
+        }
+
+        let bytes = rnd.to_ne_bytes();
+        for (b, r) in chunk.iter_mut().zip(bytes.iter()) {
+            *b = *r;
+        }
+    }
+
+    Ok(())
+}

--- a/kernel/src/tls/time_provider.rs
+++ b/kernel/src/tls/time_provider.rs
@@ -1,0 +1,36 @@
+use core::fmt::Debug;
+use core::time::Duration;
+use rustls::pki_types::UnixTime;
+use rustls::time_provider::TimeProvider;
+
+/// Rustls requires the user to provide a time provider.
+/// This implementation provides a fixed time for testing purposes.
+/// For the moment, we don't have a real time source.
+#[derive(Debug, Clone)]
+pub struct FixedTimeProvider {
+    fixed_time: UnixTime,
+}
+
+impl FixedTimeProvider {
+    /// Create a new [`FixedTimeProvider`] with a specific Unix timestamp (seconds since epoch)
+    pub fn new(timestamp_secs: u64) -> Self {
+        Self {
+            fixed_time: UnixTime::since_unix_epoch(Duration::from_secs(timestamp_secs)),
+        }
+    }
+
+    /// Create a new [`FixedTimeProvider`] with a timestamp set to December 2025
+    pub fn december_2025() -> Self {
+        const DECEMBER_2025: u64 = 1764979200; // Timestamp for December 6, 2025, 00:00:00 UTC
+        const _SEPTEMBER_2025: u64 = 1758283200; // Timestamp for September 19, 2025, 12:00:00 UTC
+        Self::new(DECEMBER_2025)
+    }
+}
+
+/// Implementation of the [`TimeProvider`] trait from rustls
+impl TimeProvider for FixedTimeProvider {
+    /// Returns the current timestamp, in this case a fixed value
+    fn current_time(&self) -> Option<UnixTime> {
+        Some(self.fixed_time)
+    }
+}

--- a/kernel/src/virtio/devices.rs
+++ b/kernel/src/virtio/devices.rs
@@ -10,6 +10,7 @@ extern crate alloc;
 use alloc::boxed::Box;
 use core::ptr::NonNull;
 use virtio_drivers::device::blk::VirtIOBlk;
+use virtio_drivers::device::socket::{VirtIOSocket, VsockConnectionManager};
 use virtio_drivers::transport::mmio::{MmioError, MmioTransport};
 use virtio_drivers::transport::{DeviceType, Transport};
 use virtio_drivers::PAGE_SIZE;
@@ -59,6 +60,50 @@ impl VirtIOBlkDevice {
 
         Ok(Box::new(VirtIOBlkDevice {
             device: SpinLock::new(blk),
+            _mmio_space: mem,
+        }))
+    }
+}
+
+pub struct VirtIOVsockDevice {
+    pub device: SpinLock<VsockConnectionManager<SvsmHal, MmioTransport<SvsmHal>>>,
+    _mmio_space: GlobalRangeGuard,
+}
+
+impl core::fmt::Debug for VirtIOVsockDevice {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("VirtIOVsockDevice").finish()
+    }
+}
+
+impl VirtIOVsockDevice {
+    pub fn new(mmio_base: PhysAddr) -> Result<Box<Self>, SvsmError> {
+        virtio_init();
+
+        let mem = map_global_range_4k_shared(mmio_base, PAGE_SIZE, PTEntryFlags::data())?;
+
+        // Not expected to fail, because mem exists.
+        let header = NonNull::new(mem.addr().as_mut_ptr()).unwrap();
+
+        // SAFETY: `header` is the MMIO config area; we have to trust the content is valid.
+        let transport = unsafe {
+            // TODO: Use more detailed error types ?
+            MmioTransport::<SvsmHal>::new(header).map_err(|e| match e {
+                MmioError::BadMagic(_) => VirtioError::InvalidDevice,
+                MmioError::UnsupportedVersion(_) => VirtioError::InvalidDevice,
+                MmioError::ZeroDeviceId => VirtioError::InvalidDevice,
+            })?
+        };
+
+        if transport.device_type() != DeviceType::Socket {
+            return Err(VirtioError::InvalidDeviceType)?;
+        }
+
+        let vsk = VirtIOSocket::new(transport).map_err(|_| VirtioError::InvalidDevice)?;
+        let mgr = VsockConnectionManager::new(vsk);
+
+        Ok(Box::new(VirtIOVsockDevice {
+            device: SpinLock::new(mgr),
             _mmio_space: mem,
         }))
     }

--- a/kernel/src/vsock/error.rs
+++ b/kernel/src/vsock/error.rs
@@ -1,0 +1,11 @@
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum VsockError {
+    /// Error when connect operation fails
+    ConnectFailed,
+    /// Error when send operation fails
+    SendFailed,
+    /// Error when recv operation fails
+    RecvFailed,
+    /// Generic error for socket operations on a vsock device.
+    Failed,
+}

--- a/kernel/src/vsock/mod.rs
+++ b/kernel/src/vsock/mod.rs
@@ -1,0 +1,5 @@
+pub mod error;
+#[cfg(all(feature = "virtio-drivers", feature = "vsock"))]
+pub mod virtio_vsock;
+
+pub use error::VsockError;

--- a/kernel/src/vsock/virtio_vsock.rs
+++ b/kernel/src/vsock/virtio_vsock.rs
@@ -70,6 +70,7 @@ impl VirtIOVsockDriver {
 
             let received = dev.recv(server_address, local_port, &mut buffer[first_clean_pos..])?;
             log::info!("[vsock] received: {received}");
+            dev.update_credit(server_address, local_port)?;
 
             first_clean_pos += received;
 

--- a/kernel/src/vsock/virtio_vsock.rs
+++ b/kernel/src/vsock/virtio_vsock.rs
@@ -1,0 +1,172 @@
+use crate::address::PhysAddr;
+use crate::error::SvsmError;
+extern crate alloc;
+use crate::fw_cfg::FwCfg;
+use crate::io::{Read, Write};
+use crate::platform::SVSM_PLATFORM;
+use crate::virtio::devices::VirtIOVsockDevice;
+use crate::vsock::VsockError;
+use alloc::boxed::Box;
+
+use virtio_drivers::device::socket::{ConnectionStatus, SocketError, VsockAddr};
+use virtio_drivers::Error;
+pub struct VirtIOVsockDriver(Box<VirtIOVsockDevice>);
+
+impl core::fmt::Debug for VirtIOVsockDriver {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("VirtIOVsockDriver").finish()
+    }
+}
+
+impl VirtIOVsockDriver {
+    pub fn new(mmio_base: PhysAddr) -> Result<Self, SvsmError> {
+        Ok(VirtIOVsockDriver(VirtIOVsockDevice::new(mmio_base)?))
+    }
+
+    pub fn connect(&self, remote_cid: u64, local_port: u32, remote_port: u32) -> Result<(), Error> {
+        let server_address = VsockAddr {
+            cid: remote_cid,
+            port: remote_port,
+        };
+
+        self.0
+            .device
+            .locked_do(|dev| dev.connect(server_address, local_port))?;
+
+        loop {
+            let mut dev = self.0.device.lock();
+
+            dev.wait_for_event()?;
+            let status = dev.get_connection_status(server_address, local_port)?;
+
+            match status {
+                ConnectionStatus::Connected => {
+                    return Ok(());
+                }
+                ConnectionStatus::Connecting => {}
+                _ => {
+                    return Err(SocketError::NotConnected.into());
+                }
+            }
+        }
+    }
+
+    pub fn recv(
+        &self,
+        remote_cid: u64,
+        local_port: u32,
+        remote_port: u32,
+        buffer: &mut [u8],
+    ) -> Result<usize, Error> {
+        let mut first_clean_pos: usize = 0;
+
+        loop {
+            let mut dev = self.0.device.lock();
+
+            let server_address = VsockAddr {
+                cid: remote_cid,
+                port: remote_port,
+            };
+
+            let received = dev.recv(server_address, local_port, &mut buffer[first_clean_pos..])?;
+            log::info!("[vsock] received: {received}");
+
+            first_clean_pos += received;
+
+            if received < buffer.len() && first_clean_pos != buffer.len() {
+                dev.wait_for_event()?;
+            } else {
+                break;
+            }
+        }
+
+        Ok(buffer.len())
+    }
+
+    pub fn send(
+        &self,
+        remote_cid: u64,
+        local_port: u32,
+        remote_port: u32,
+        buffer: &[u8],
+    ) -> Result<usize, Error> {
+        let mut dev = self.0.device.lock();
+
+        let server_address = VsockAddr {
+            cid: remote_cid,
+            port: remote_port,
+        };
+
+        dev.send(server_address, local_port, buffer)?;
+        Ok(buffer.len())
+    }
+
+    pub fn close(&self, remote_cid: u64, local_port: u32, remote_port: u32) -> Result<(), Error> {
+        let mut dev = self.0.device.lock();
+
+        let server_address = VsockAddr {
+            cid: remote_cid,
+            port: remote_port,
+        };
+
+        dev.shutdown(server_address, local_port)
+    }
+}
+
+#[derive(Debug)]
+pub struct VsockStream {
+    local_port: u32,
+    remote_port: u32,
+    remote_cid: u64,
+    driver: VirtIOVsockDriver,
+}
+
+impl VsockStream {
+    pub fn connect(local_port: u32, remote_port: u32, remote_cid: u64) -> Result<Self, SvsmError> {
+        let cfg = FwCfg::new(SVSM_PLATFORM.get_io_port());
+
+        let driver = cfg
+            .get_virtio_mmio_addresses()
+            .unwrap_or_default()
+            .iter()
+            .find_map(|a| VirtIOVsockDriver::new(PhysAddr::from(*a)).ok())
+            .ok_or(SvsmError::Vsock(VsockError::Failed))?;
+
+        if driver.connect(remote_cid, local_port, remote_port).is_err() {
+            return Err(SvsmError::Vsock(VsockError::ConnectFailed));
+        }
+
+        Ok(Self {
+            local_port,
+            remote_port,
+            remote_cid,
+            driver,
+        })
+    }
+
+    pub fn close(&self) -> Result<(), SvsmError> {
+        self.driver
+            .close(self.remote_cid, self.local_port, self.remote_port)
+            .map_err(|_| SvsmError::Vsock(VsockError::Failed))
+    }
+}
+
+impl Read for VsockStream {
+    type Err = SvsmError;
+
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Err> {
+        self.driver
+            .recv(self.remote_cid, self.local_port, self.remote_port, buf)
+            .map_err(|_| SvsmError::Vsock(VsockError::RecvFailed))
+    }
+}
+
+impl Write for VsockStream {
+    type Err = SvsmError;
+
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Err> {
+        self.driver
+            .send(self.remote_cid, self.local_port, self.remote_port, buf)
+            .map_err(|_| SvsmError::Vsock(VsockError::SendFailed))
+    }
+}

--- a/kernel/src/vsock/virtio_vsock.rs
+++ b/kernel/src/vsock/virtio_vsock.rs
@@ -170,3 +170,81 @@ impl Write for VsockStream {
             .map_err(|_| SvsmError::Vsock(VsockError::SendFailed))
     }
 }
+
+#[cfg(all(test, test_in_svsm))]
+mod tests {
+    use crate::{
+        address::PhysAddr, fw_cfg::FwCfg, platform::SVSM_PLATFORM, testutils::has_test_iorequests,
+    };
+
+    use super::*;
+
+    fn start_vsock_server_host() {
+        use crate::serial::Terminal;
+        use crate::testing::{svsm_test_io, IORequest};
+
+        let sp = svsm_test_io().unwrap();
+
+        sp.put_byte(IORequest::StartVsockServer as u8);
+
+        let _ = sp.get_byte();
+    }
+
+    fn get_vsock_device() -> VirtIOVsockDriver {
+        let cfg = FwCfg::new(SVSM_PLATFORM.get_io_port());
+
+        let dev = cfg
+            .get_virtio_mmio_addresses()
+            .unwrap_or_default()
+            .iter()
+            .find_map(|a| VirtIOVsockDriver::new(PhysAddr::from(*a)).ok())
+            .expect("No virtio-vsock device found");
+
+        dev
+    }
+
+    #[test]
+    #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
+    fn test_virtio_vsock() {
+        if !has_test_iorequests() {
+            return;
+        }
+
+        start_vsock_server_host();
+
+        let device = get_vsock_device();
+
+        let cid = 2;
+        let local_port = 1234;
+        let remote_port = 12345;
+
+        device
+            .connect(cid, local_port, remote_port)
+            .expect("Connection failed");
+
+        device
+            .connect(cid, local_port, remote_port)
+            .expect_err("The second connection operation was expected to fail, but it succeeded.");
+
+        let mut buffer: [u8; 11] = [0; 11];
+        let n_bytes = device
+            .recv(cid, local_port, remote_port, &mut buffer)
+            .expect("Recv failed");
+
+        assert!(
+            n_bytes == buffer.len(),
+            "Received less bytes than requested"
+        );
+
+        let string = core::str::from_utf8(&buffer).unwrap();
+        log::info!("received: {string:?}");
+
+        device
+            .close(cid, local_port, remote_port)
+            .expect("Close failed");
+
+        device
+            .send(cid, local_port, remote_port, &buffer)
+            .expect_err("The send operation was expected to fail, but it succeeded.");
+    }
+}

--- a/scripts/gen_ca_server_certs.sh
+++ b/scripts/gen_ca_server_certs.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+set -e 
+# --- Create output directory --- 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+OUTPUT_DIR="$(realpath "$SCRIPT_DIR/../certificates")"
+mkdir -p "$OUTPUT_DIR" 
+
+# --- Configs --- 
+ROOT_CA_NAME="Test Root CA" 
+ROOT_CA_COUNTRY="IT" 
+ROOT_CA_ORG="TestCA" 
+ROOT_CA_VALIDITY_DAYS=3650 
+ROOT_CA_STATE="Italy" 
+ROOT_CA_LOCALITY="Pisa"
+SERVER_NAME="localhost" 
+SERVER_IP="127.0.0.1"
+SERVER_COUNTRY="IT" 
+SERVER_ORG="TestServer" 
+SERVER_STATE="Italy"
+SERVER_LOCALITY="Pisa"
+SERVER_VALIDITY_DAYS=365 
+
+# File output 
+CA_KEY="$OUTPUT_DIR/ca.key" 
+CA_CERT="$OUTPUT_DIR/ca.crt" 
+CA_DER="$OUTPUT_DIR/ca.der" 
+SERVER_KEY="$OUTPUT_DIR/server.key" 
+SERVER_CSR="$OUTPUT_DIR/server.csr" 
+SERVER_CERT="$OUTPUT_DIR/server.crt" 
+SERVER_EXT="$OUTPUT_DIR/server_ext.cnf" 
+
+# --- 1. Create CA private key --- 
+echo "Creating CA private key..." 
+openssl genrsa -out "$CA_KEY" 4096 
+
+# --- 2. Create CA root certificate (self-signed) --- 
+echo "Creating CA root certificate..." 
+openssl req -x509 -new -nodes \
+    -key "$CA_KEY" \
+    -sha256 \
+    -days $ROOT_CA_VALIDITY_DAYS \
+    -out "$CA_CERT" \
+    -subj "/C=$ROOT_CA_COUNTRY/ST=$ROOT_CA_STATE/L=$ROOT_CA_LOCALITY/O=$ROOT_CA_ORG/CN=$ROOT_CA_NAME"   
+
+# --- 3. Convert CA certificate to DER for client ---
+echo "Converting CA certificate to DER format..." 
+openssl x509 \
+    -in "$CA_CERT" \
+    -outform der \
+    -out "$CA_DER"
+
+# --- 4. Create server private key --- 
+echo "Creating server private key..."
+openssl genrsa \
+    -out "$SERVER_KEY" \
+    2048
+
+# --- 5. Create SAN extensions file ---
+echo "Creating SAN extensions file..."
+cat > "$SERVER_EXT" <<EOL
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = $SERVER_NAME
+IP.1 = $SERVER_IP
+EOL
+
+# --- 6. Create server CSR (with SAN) ---
+echo "Creating server CSR..."
+openssl req -new \
+    -key "$SERVER_KEY" \
+    -out "$SERVER_CSR" \
+    -subj "/C=$SERVER_COUNTRY/ST=$SERVER_STATE/L=$SERVER_LOCALITY/O=$SERVER_ORG/CN=$SERVER_NAME" \
+    -config "$SERVER_EXT"
+
+# --- 7. Sign server certificate with CA --- 
+echo "Signing server certificate with CA..." 
+openssl x509 -req \
+    -in "$SERVER_CSR" \
+    -CA "$CA_CERT" \
+    -CAkey "$CA_KEY" \
+    -CAcreateserial \
+    -out "$SERVER_CERT" \
+    -days $SERVER_VALIDITY_DAYS \
+    -sha256 \
+    -extfile "$SERVER_EXT"
+
+echo "=== Operation completed ==="
+echo "CA certificate: $CA_CERT"
+echo "CA certificate (DER): $CA_DER"
+echo "Server certificate: $SERVER_CERT"
+echo "Server private key: $SERVER_KEY"

--- a/scripts/launch_https_test.sh
+++ b/scripts/launch_https_test.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+set -e
+trap cleanup EXIT INT TERM
+
+# --- Cleanup function to terminate background processes ---
+cleanup() {
+    echo "[*] Cleaning up background processes..."
+    for pid in "${pids[@]}"; do
+        if kill -0 "$pid" 2>/dev/null; then
+            kill "$pid"
+            wait "$pid" 2>/dev/null || true
+        fi
+    done
+
+    if [ -f "$HELLO_FILE" ]; then
+        rm  -f "$HELLO_FILE"
+    fi
+}
+
+# --- Flag default ---
+GEN_CERTS=true
+NO_COMPILE=false
+PORT=4433
+
+# --- Track background PIDs ---
+pids=()
+
+# --- Paths and files ---
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+OUTPUT_DIR=$(realpath "$SCRIPT_DIR/../certificates")
+CA_CERT="$OUTPUT_DIR/ca.crt"
+SERVER_CERT="$OUTPUT_DIR/server.crt"
+SERVER_KEY="$OUTPUT_DIR/server.key"
+HELLO_FILE="hello.html"
+
+# --- Parsing flags ---
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --no-gen-certs|-ng)
+            GEN_CERTS=false
+            shift
+            ;;
+        --port|-p)
+            PORT="$2"
+            shift 2
+            ;;
+        --no-compile|-nc)
+            NO_COMPILE=true
+            shift
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+# 1. Generate certificates if needed
+if [ "$GEN_CERTS" = true ]; then
+    rm -rf "$OUTPUT_DIR"
+    echo "[*] Generating new certificates..."
+    "$SCRIPT_DIR/gen_ca_server_certs.sh"
+else    
+    if [ ! -f "$CA_CERT" ] || [ ! -f "$SERVER_CERT" ] || [ ! -f "$SERVER_KEY" ]; then
+        echo "Error: Certificates not found in $OUTPUT_DIR. Please run without --no-gen-certs to generate them."
+        exit 1
+    else
+        echo "[*] Using existing certificates in $OUTPUT_DIR"
+    fi
+fi
+
+# 2. Build with TLS feature
+if [ "$NO_COMPILE" = true ]; then
+    echo "[*] Skipping compilation as per --no-compile flag."
+else
+    echo "[*] Building with TLS feature..."
+    make FEATURES=tls
+fi
+
+# 3. Start socat in background (output to file)
+echo "[*] Starting socat in background..."
+socat -d -d VSOCK-LISTEN:12345,reuseaddr TCP:localhost:$PORT > socat.log 2>&1 &
+
+# 4. Example file creation
+echo "Creating example file to serve..."
+echo "Hello, World!" > "$HELLO_FILE"
+
+# 5. Start openssl s_server in background (output to file)
+echo "[*] Starting openssl s_server in background..."
+openssl s_server \
+    -key "$SERVER_KEY" \
+    -cert "$SERVER_CERT" \
+    -port "$PORT" \
+    -tls1_3 \
+    -WWW \
+    -keylogfile tls_keylog.log \
+    > /dev/null 2>&1 &
+pids+=($!)
+
+# 6. Launch guest VM (this stays in foreground)
+echo "[*] Launching guest with QEMU=$QEMU ..."
+"$SCRIPT_DIR/launch_guest.sh" --nocc --vsock 3

--- a/scripts/test-in-svsm.sh
+++ b/scripts/test-in-svsm.sh
@@ -28,6 +28,11 @@ test_io(){
             "02")
               sha256sum "$TEST_DIR/svsm_state.raw" | cut -f 1 -d ' ' | xxd -p -r > "$PIPE_IN"
               ;;
+            "03")
+              echo -n "hello_world" | nc -l --vsock 12345 &
+              sleep 1
+              echo -n "0" > $PIPE_IN
+              ;;
             "")
                 # skip EOF
                 ;;
@@ -49,6 +54,7 @@ TEST_IO_PID=$!
 
 $SCRIPT_DIR/launch_guest.sh --igvm $SCRIPT_DIR/../bin/coconut-test-qemu.igvm \
     --state "$TEST_DIR/svsm_state.raw" \
+    --vsock 3 \
     --unit-tests $TEST_DIR/pipe || true
 
 kill $TEST_IO_PID 2> /dev/null || true

--- a/tls_command_server/command_server.py
+++ b/tls_command_server/command_server.py
@@ -1,0 +1,97 @@
+import socket
+import ssl
+
+# TLS certificate and private key paths
+CERTFILE = './certificates/server.crt'
+KEYFILE = './certificates/server.key'
+
+# TCP/IP host and port
+HOST = "127.0.0.1"     # Listen on localhost
+PORT = 4433            # TLS server port
+
+BUFFER_SIZE = 4096
+
+def create_tls_context(certfile: str, keyfile: str, keylog_file: str = None) -> ssl.SSLContext:
+    """
+    Create and configure an SSL/TLS context for the server.
+    """
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(certfile=certfile, keyfile=keyfile)
+    if keylog_file:
+        context.keylog_filename = keylog_file  # Useful for Wireshark using TCP and not VSOCK
+    return context
+
+def receive_response(connstream: ssl.SSLSocket, buffer_size: int = BUFFER_SIZE) -> str:
+    """
+    Receive a response from the client.
+    Returns the decoded response string, or None if the client closed the connection.
+    """
+    data = connstream.recv(buffer_size)
+    if not data:
+        return None
+    return data.decode(errors='ignore')
+
+def handle_client(connstream: ssl.SSLSocket) -> None:
+    """
+    Handle the interaction with a single TLS client.
+    """
+    while True:
+        cmd = input("Command to send to client A ('EXIT' to close) > ") 
+        
+        if cmd.lower() == "shutdown":
+            connstream.unwrap()
+            break    
+        
+        # Send command
+        connstream.sendall(cmd.encode())
+
+        # Receive and print the client's response
+        response = receive_response(connstream)
+        if response:
+            print("[CLIENT A]:", response)
+        else:
+            print("[*] Client A closed the connection")
+            break
+        
+        if cmd.lower() == "exit" :
+            print("[*] EXIT command sent, closing connection")
+            connstream.unwrap()  # Perform TLS shutdown handshake
+            break
+
+def main():
+    """
+    TLS server that accepts a single client connection,
+    sends commands to the client, and receives responses.
+    """
+    # --- Socket creation ---
+    bindsocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    bindsocket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    bindsocket.bind((HOST, PORT))
+    bindsocket.listen(5)
+    print(f"[*] TLS server listening on {HOST}:{PORT}")
+
+    # --- SSL/TLS context ---
+    context = create_tls_context(CERTFILE, KEYFILE, keylog_file="tls_keylog.log")
+
+    # --- Accept client connection ---
+    newsocket, fromaddr = bindsocket.accept()
+    print(f"[*] Incoming TLS connection from {fromaddr}")
+
+    # Wrap the socket with TLS
+    connstream = context.wrap_socket(newsocket, server_side=True)
+
+    try:
+        handle_client(connstream)
+    except ssl.SSLError as e:
+        print("[!] SSL Error:", e)
+    except Exception as e:
+        print("[!] Error:", e)
+    except KeyboardInterrupt:
+        print("\n[*] Server interrupted by user")
+    finally:
+        connstream.close()
+        bindsocket.close()
+        print("[*] Connection closed")
+
+if __name__ == "__main__":
+    main()

--- a/virtio-drivers/Cargo.toml
+++ b/virtio-drivers/Cargo.toml
@@ -18,7 +18,9 @@ log = { workspace = true }
 bitflags = { workspace = true }
 enumn = "0.1.14"
 zerocopy = { workspace = true, features = ["derive"] }
+embedded-io = { version = "0.6.1", optional = true }
 
 [features]
-default = ["alloc"]
+default = ["alloc", "embedded-io"]
 alloc = ["zerocopy/alloc"]
+embedded-io = ["dep:embedded-io"]

--- a/virtio-drivers/src/device/mod.rs
+++ b/virtio-drivers/src/device/mod.rs
@@ -3,4 +3,6 @@
 //! Drivers for specific VirtIO devices.
 
 pub mod blk;
+pub mod socket;
+
 pub(crate) mod common;

--- a/virtio-drivers/src/device/socket/connectionmanager.rs
+++ b/virtio-drivers/src/device/socket/connectionmanager.rs
@@ -1,0 +1,804 @@
+use super::{
+    protocol::VsockAddr, vsock::ConnectionInfo, DisconnectReason, SocketError, VirtIOSocket,
+    VsockEvent, VsockEventType, DEFAULT_RX_BUFFER_SIZE,
+};
+use crate::{transport::Transport, Hal, Result};
+use alloc::{boxed::Box, vec::Vec};
+use core::cmp::min;
+use core::convert::TryInto;
+use core::hint::spin_loop;
+use log::debug;
+use zerocopy::FromZeros;
+
+const DEFAULT_PER_CONNECTION_BUFFER_CAPACITY: u32 = 1024;
+
+/// A higher level interface for VirtIO socket (vsock) devices.
+///
+/// This keeps track of multiple vsock connections.
+///
+/// `RX_BUFFER_SIZE` is the size in bytes of each buffer used in the RX virtqueue. This must be
+/// bigger than `size_of::<VirtioVsockHdr>()`.
+///
+/// # Example
+///
+/// ```
+/// # use virtio_drivers::{Error, Hal};
+/// # use virtio_drivers::transport::Transport;
+/// use virtio_drivers::device::socket::{VirtIOSocket, VsockAddr, VsockConnectionManager};
+///
+/// # fn example<HalImpl: Hal, T: Transport>(transport: T) -> Result<(), Error> {
+/// let mut socket = VsockConnectionManager::new(VirtIOSocket::<HalImpl, _>::new(transport)?);
+///
+/// // Start a thread to call `socket.poll()` and handle events.
+///
+/// let remote_address = VsockAddr { cid: 2, port: 42 };
+/// let local_port = 1234;
+/// socket.connect(remote_address, local_port)?;
+///
+/// // Wait until `socket.poll()` returns an event indicating that the socket is connected.
+///
+/// socket.send(remote_address, local_port, "Hello world".as_bytes())?;
+///
+/// socket.shutdown(remote_address, local_port)?;
+/// # Ok(())
+/// # }
+/// ```
+pub struct VsockConnectionManager<
+    H: Hal,
+    T: Transport,
+    const RX_BUFFER_SIZE: usize = DEFAULT_RX_BUFFER_SIZE,
+> {
+    driver: VirtIOSocket<H, T, RX_BUFFER_SIZE>,
+    per_connection_buffer_capacity: u32,
+    connections: Vec<Connection>,
+    listening_ports: Vec<u32>,
+}
+
+#[derive(Debug)]
+struct Connection {
+    info: ConnectionInfo,
+    buffer: RingBuffer,
+    /// The peer sent a SHUTDOWN request, but we haven't yet responded with a RST because there is
+    /// still data in the buffer.
+    peer_requested_shutdown: bool,
+}
+
+impl Connection {
+    fn new(peer: VsockAddr, local_port: u32, buffer_capacity: u32) -> Self {
+        let mut info = ConnectionInfo::new(peer, local_port);
+        info.buf_alloc = buffer_capacity;
+        Self {
+            info,
+            buffer: RingBuffer::new(buffer_capacity.try_into().unwrap()),
+            peer_requested_shutdown: false,
+        }
+    }
+}
+
+impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize>
+    VsockConnectionManager<H, T, RX_BUFFER_SIZE>
+{
+    /// Construct a new connection manager wrapping the given low-level VirtIO socket driver.
+    pub fn new(driver: VirtIOSocket<H, T, RX_BUFFER_SIZE>) -> Self {
+        Self::new_with_capacity(driver, DEFAULT_PER_CONNECTION_BUFFER_CAPACITY)
+    }
+
+    /// Construct a new connection manager wrapping the given low-level VirtIO socket driver, with
+    /// the given per-connection buffer capacity.
+    pub fn new_with_capacity(
+        driver: VirtIOSocket<H, T, RX_BUFFER_SIZE>,
+        per_connection_buffer_capacity: u32,
+    ) -> Self {
+        Self {
+            driver,
+            connections: Vec::new(),
+            listening_ports: Vec::new(),
+            per_connection_buffer_capacity,
+        }
+    }
+
+    /// Returns the CID which has been assigned to this guest.
+    pub fn guest_cid(&self) -> u64 {
+        self.driver.guest_cid()
+    }
+
+    /// Allows incoming connections on the given port number.
+    pub fn listen(&mut self, port: u32) {
+        if !self.listening_ports.contains(&port) {
+            self.listening_ports.push(port);
+        }
+    }
+
+    /// Stops allowing incoming connections on the given port number.
+    pub fn unlisten(&mut self, port: u32) {
+        self.listening_ports.retain(|p| *p != port);
+    }
+
+    /// Sends a request to connect to the given destination.
+    ///
+    /// This returns as soon as the request is sent; you should wait until `poll` returns a
+    /// `VsockEventType::Connected` event indicating that the peer has accepted the connection
+    /// before sending data.
+    pub fn connect(&mut self, destination: VsockAddr, src_port: u32) -> Result {
+        if self.connections.iter().any(|connection| {
+            connection.info.dst == destination && connection.info.src_port == src_port
+        }) {
+            return Err(SocketError::ConnectionExists.into());
+        }
+
+        let new_connection =
+            Connection::new(destination, src_port, self.per_connection_buffer_capacity);
+
+        self.driver.connect(&new_connection.info)?;
+        debug!("Connection requested: {:?}", new_connection.info);
+        self.connections.push(new_connection);
+        Ok(())
+    }
+
+    /// Sends the buffer to the destination.
+    pub fn send(&mut self, destination: VsockAddr, src_port: u32, buffer: &[u8]) -> Result {
+        let (_, connection) = get_connection(&mut self.connections, destination, src_port)?;
+
+        self.driver.send(buffer, &mut connection.info)
+    }
+
+    /// Polls the vsock device to receive data or other updates.
+    pub fn poll(&mut self) -> Result<Option<VsockEvent>> {
+        let guest_cid = self.driver.guest_cid();
+        let connections = &mut self.connections;
+        let per_connection_buffer_capacity = self.per_connection_buffer_capacity;
+
+        let result = self.driver.poll(|event, body| {
+            let connection = get_connection_for_event(connections, &event, guest_cid);
+
+            // Skip events which don't match any connection we know about, unless they are a
+            // connection request.
+            let connection = if let Some((_, connection)) = connection {
+                connection
+            } else if let VsockEventType::ConnectionRequest = event.event_type {
+                // If the requested connection already exists or the CID isn't ours, ignore it.
+                if connection.is_some() || event.destination.cid != guest_cid {
+                    return Ok(None);
+                }
+                // Add the new connection to our list, at least for now. It will be removed again
+                // below if we weren't listening on the port.
+                connections.push(Connection::new(
+                    event.source,
+                    event.destination.port,
+                    per_connection_buffer_capacity,
+                ));
+                connections.last_mut().unwrap()
+            } else {
+                return Ok(None);
+            };
+
+            // Update stored connection info.
+            connection.info.update_for_event(&event);
+
+            if let VsockEventType::Received { length } = event.event_type {
+                // Copy to buffer
+                if !connection.buffer.add(body) {
+                    return Err(SocketError::OutputBufferTooShort(length).into());
+                }
+            }
+
+            Ok(Some(event))
+        })?;
+
+        let Some(event) = result else {
+            return Ok(None);
+        };
+
+        // The connection must exist because we found it above in the callback.
+        let (connection_index, connection) =
+            get_connection_for_event(connections, &event, guest_cid).unwrap();
+
+        match event.event_type {
+            VsockEventType::ConnectionRequest => {
+                if self.listening_ports.contains(&event.destination.port) {
+                    self.driver.accept(&connection.info)?;
+                } else {
+                    // Reject the connection request and remove it from our list.
+                    self.driver.force_close(&connection.info)?;
+                    self.connections.swap_remove(connection_index);
+
+                    // No need to pass the request on to the client, as we've already rejected it.
+                    return Ok(None);
+                }
+            }
+            VsockEventType::Connected => {}
+            VsockEventType::Disconnected { reason } => {
+                // Wait until client reads all data before removing connection.
+                if connection.buffer.is_empty() {
+                    if reason == DisconnectReason::Shutdown {
+                        self.driver.force_close(&connection.info)?;
+                    }
+                    self.connections.swap_remove(connection_index);
+                } else {
+                    connection.peer_requested_shutdown = true;
+                }
+            }
+            VsockEventType::Received { .. } => {
+                // Already copied the buffer in the callback above.
+            }
+            VsockEventType::CreditRequest => {
+                // If the peer requested credit, send an update.
+                self.driver.credit_update(&connection.info)?;
+                // No need to pass the request on to the client, we've already handled it.
+                return Ok(None);
+            }
+            VsockEventType::CreditUpdate => {}
+        }
+
+        Ok(Some(event))
+    }
+
+    /// Reads data received from the given connection.
+    pub fn recv(&mut self, peer: VsockAddr, src_port: u32, buffer: &mut [u8]) -> Result<usize> {
+        let (connection_index, connection) = get_connection(&mut self.connections, peer, src_port)?;
+
+        // Copy from ring buffer
+        let bytes_read = connection.buffer.drain(buffer);
+
+        connection.info.done_forwarding(bytes_read);
+
+        // If buffer is now empty and the peer requested shutdown, finish shutting down the
+        // connection.
+        if connection.peer_requested_shutdown && connection.buffer.is_empty() {
+            self.driver.force_close(&connection.info)?;
+            self.connections.swap_remove(connection_index);
+        }
+
+        Ok(bytes_read)
+    }
+
+    /// Returns the number of bytes in the receive buffer available to be read by `recv`.
+    ///
+    /// When the available bytes is 0, it indicates that the receive buffer is empty and does not
+    /// contain any data.
+    pub fn recv_buffer_available_bytes(&mut self, peer: VsockAddr, src_port: u32) -> Result<usize> {
+        let (_, connection) = get_connection(&mut self.connections, peer, src_port)?;
+        Ok(connection.buffer.used())
+    }
+
+    /// Sends a credit update to the given peer.
+    pub fn update_credit(&mut self, peer: VsockAddr, src_port: u32) -> Result {
+        let (_, connection) = get_connection(&mut self.connections, peer, src_port)?;
+        self.driver.credit_update(&connection.info)
+    }
+
+    /// Blocks until we get some event from the vsock device.
+    pub fn wait_for_event(&mut self) -> Result<VsockEvent> {
+        loop {
+            if let Some(event) = self.poll()? {
+                return Ok(event);
+            } else {
+                spin_loop();
+            }
+        }
+    }
+
+    /// Requests to shut down the connection cleanly, telling the peer that we won't send or receive
+    /// any more data.
+    ///
+    /// This returns as soon as the request is sent; you should wait until `poll` returns a
+    /// `VsockEventType::Disconnected` event if you want to know that the peer has acknowledged the
+    /// shutdown.
+    pub fn shutdown(&mut self, destination: VsockAddr, src_port: u32) -> Result {
+        let (_, connection) = get_connection(&mut self.connections, destination, src_port)?;
+
+        self.driver.shutdown(&connection.info)
+    }
+
+    /// Forcibly closes the connection without waiting for the peer.
+    pub fn force_close(&mut self, destination: VsockAddr, src_port: u32) -> Result {
+        let (index, connection) = get_connection(&mut self.connections, destination, src_port)?;
+
+        self.driver.force_close(&connection.info)?;
+
+        self.connections.swap_remove(index);
+        Ok(())
+    }
+}
+
+/// Returns the connection from the given list matching the given peer address and local port, and
+/// its index.
+///
+/// Returns `Err(SocketError::NotConnected)` if there is no matching connection in the list.
+fn get_connection(
+    connections: &mut [Connection],
+    peer: VsockAddr,
+    local_port: u32,
+) -> core::result::Result<(usize, &mut Connection), SocketError> {
+    connections
+        .iter_mut()
+        .enumerate()
+        .find(|(_, connection)| {
+            connection.info.dst == peer && connection.info.src_port == local_port
+        })
+        .ok_or(SocketError::NotConnected)
+}
+
+/// Returns the connection from the given list matching the event, if any, and its index.
+fn get_connection_for_event<'a>(
+    connections: &'a mut [Connection],
+    event: &VsockEvent,
+    local_cid: u64,
+) -> Option<(usize, &'a mut Connection)> {
+    connections
+        .iter_mut()
+        .enumerate()
+        .find(|(_, connection)| event.matches_connection(&connection.info, local_cid))
+}
+
+#[derive(Debug)]
+struct RingBuffer {
+    buffer: Box<[u8]>,
+    /// The number of bytes currently in the buffer.
+    used: usize,
+    /// The index of the first used byte in the buffer.
+    start: usize,
+}
+
+impl RingBuffer {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            buffer: FromZeros::new_box_zeroed_with_elems(capacity).unwrap(),
+            used: 0,
+            start: 0,
+        }
+    }
+
+    /// Returns the number of bytes currently used in the buffer.
+    pub fn used(&self) -> usize {
+        self.used
+    }
+
+    /// Returns true iff there are currently no bytes in the buffer.
+    pub fn is_empty(&self) -> bool {
+        self.used == 0
+    }
+
+    /// Returns the number of bytes currently free in the buffer.
+    pub fn free(&self) -> usize {
+        self.buffer.len() - self.used
+    }
+
+    /// Adds the given bytes to the buffer if there is enough capacity for them all.
+    ///
+    /// Returns true if they were added, or false if they were not.
+    pub fn add(&mut self, bytes: &[u8]) -> bool {
+        if bytes.len() > self.free() {
+            return false;
+        }
+
+        // The index of the first available position in the buffer.
+        let first_available = (self.start + self.used) % self.buffer.len();
+        // The number of bytes to copy from `bytes` to `buffer` between `first_available` and
+        // `buffer.len()`.
+        let copy_length_before_wraparound = min(bytes.len(), self.buffer.len() - first_available);
+        self.buffer[first_available..first_available + copy_length_before_wraparound]
+            .copy_from_slice(&bytes[0..copy_length_before_wraparound]);
+        if let Some(bytes_after_wraparound) = bytes.get(copy_length_before_wraparound..) {
+            self.buffer[0..bytes_after_wraparound.len()].copy_from_slice(bytes_after_wraparound);
+        }
+        self.used += bytes.len();
+
+        true
+    }
+
+    /// Reads and removes as many bytes as possible from the buffer, up to the length of the given
+    /// buffer.
+    pub fn drain(&mut self, out: &mut [u8]) -> usize {
+        let bytes_read = min(self.used, out.len());
+
+        // The number of bytes to copy out between `start` and the end of the buffer.
+        let read_before_wraparound = min(bytes_read, self.buffer.len() - self.start);
+        // The number of bytes to copy out from the beginning of the buffer after wrapping around.
+        let read_after_wraparound = bytes_read
+            .checked_sub(read_before_wraparound)
+            .unwrap_or_default();
+
+        out[0..read_before_wraparound]
+            .copy_from_slice(&self.buffer[self.start..self.start + read_before_wraparound]);
+        out[read_before_wraparound..bytes_read]
+            .copy_from_slice(&self.buffer[0..read_after_wraparound]);
+
+        self.used -= bytes_read;
+        self.start = (self.start + bytes_read) % self.buffer.len();
+
+        bytes_read
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        device::socket::{
+            protocol::{
+                SocketType, StreamShutdown, VirtioVsockConfig, VirtioVsockHdr, VirtioVsockOp,
+            },
+            vsock::{VsockBufferStatus, QUEUE_SIZE, RX_QUEUE_IDX, TX_QUEUE_IDX},
+        },
+        hal::fake::FakeHal,
+        transport::{
+            fake::{FakeTransport, QueueStatus, State},
+            DeviceType,
+        },
+        volatile::ReadOnly,
+    };
+    use alloc::{sync::Arc, vec};
+    use core::{mem::size_of, ptr::NonNull};
+    use std::{sync::Mutex, thread};
+    use zerocopy::{FromBytes, IntoBytes};
+
+    #[test]
+    fn send_recv() {
+        let host_cid = 2;
+        let guest_cid = 66;
+        let host_port = 1234;
+        let guest_port = 4321;
+        let host_address = VsockAddr {
+            cid: host_cid,
+            port: host_port,
+        };
+        let hello_from_guest = "Hello from guest";
+        let hello_from_host = "Hello from host";
+
+        let mut config_space = VirtioVsockConfig {
+            guest_cid_low: ReadOnly::new(66),
+            guest_cid_high: ReadOnly::new(0),
+        };
+        let state = Arc::new(Mutex::new(State {
+            queues: vec![
+                QueueStatus::default(),
+                QueueStatus::default(),
+                QueueStatus::default(),
+            ],
+            ..Default::default()
+        }));
+        let transport = FakeTransport {
+            device_type: DeviceType::Socket,
+            max_queue_size: 32,
+            device_features: 0,
+            config_space: NonNull::from(&mut config_space),
+            state: state.clone(),
+        };
+        let mut socket = VsockConnectionManager::new(
+            VirtIOSocket::<FakeHal, FakeTransport<VirtioVsockConfig>>::new(transport).unwrap(),
+        );
+
+        // Start a thread to simulate the device.
+        let handle = thread::spawn(move || {
+            // Wait for connection request.
+            State::wait_until_queue_notified(&state, TX_QUEUE_IDX);
+            assert_eq!(
+                VirtioVsockHdr::read_from_bytes(
+                    state
+                        .lock()
+                        .unwrap()
+                        .read_from_queue::<QUEUE_SIZE>(TX_QUEUE_IDX)
+                        .as_slice()
+                )
+                .unwrap(),
+                VirtioVsockHdr {
+                    op: VirtioVsockOp::Request.into(),
+                    src_cid: guest_cid.into(),
+                    dst_cid: host_cid.into(),
+                    src_port: guest_port.into(),
+                    dst_port: host_port.into(),
+                    len: 0.into(),
+                    socket_type: SocketType::Stream.into(),
+                    flags: 0.into(),
+                    buf_alloc: 1024.into(),
+                    fwd_cnt: 0.into(),
+                }
+            );
+
+            // Accept connection and give the peer enough credit to send the message.
+            state.lock().unwrap().write_to_queue::<QUEUE_SIZE>(
+                RX_QUEUE_IDX,
+                VirtioVsockHdr {
+                    op: VirtioVsockOp::Response.into(),
+                    src_cid: host_cid.into(),
+                    dst_cid: guest_cid.into(),
+                    src_port: host_port.into(),
+                    dst_port: guest_port.into(),
+                    len: 0.into(),
+                    socket_type: SocketType::Stream.into(),
+                    flags: 0.into(),
+                    buf_alloc: 50.into(),
+                    fwd_cnt: 0.into(),
+                }
+                .as_bytes(),
+            );
+
+            // Expect the guest to send some data.
+            State::wait_until_queue_notified(&state, TX_QUEUE_IDX);
+            let request = state
+                .lock()
+                .unwrap()
+                .read_from_queue::<QUEUE_SIZE>(TX_QUEUE_IDX);
+            assert_eq!(
+                request.len(),
+                size_of::<VirtioVsockHdr>() + hello_from_guest.len()
+            );
+            assert_eq!(
+                VirtioVsockHdr::read_from_prefix(request.as_slice())
+                    .unwrap()
+                    .0,
+                VirtioVsockHdr {
+                    op: VirtioVsockOp::Rw.into(),
+                    src_cid: guest_cid.into(),
+                    dst_cid: host_cid.into(),
+                    src_port: guest_port.into(),
+                    dst_port: host_port.into(),
+                    len: (hello_from_guest.len() as u32).into(),
+                    socket_type: SocketType::Stream.into(),
+                    flags: 0.into(),
+                    buf_alloc: 1024.into(),
+                    fwd_cnt: 0.into(),
+                }
+            );
+            assert_eq!(
+                &request[size_of::<VirtioVsockHdr>()..],
+                hello_from_guest.as_bytes()
+            );
+
+            println!("Host sending");
+
+            // Send a response.
+            let mut response = vec![0; size_of::<VirtioVsockHdr>() + hello_from_host.len()];
+            VirtioVsockHdr {
+                op: VirtioVsockOp::Rw.into(),
+                src_cid: host_cid.into(),
+                dst_cid: guest_cid.into(),
+                src_port: host_port.into(),
+                dst_port: guest_port.into(),
+                len: (hello_from_host.len() as u32).into(),
+                socket_type: SocketType::Stream.into(),
+                flags: 0.into(),
+                buf_alloc: 50.into(),
+                fwd_cnt: (hello_from_guest.len() as u32).into(),
+            }
+            .write_to_prefix(response.as_mut_slice())
+            .unwrap();
+            response[size_of::<VirtioVsockHdr>()..].copy_from_slice(hello_from_host.as_bytes());
+            state
+                .lock()
+                .unwrap()
+                .write_to_queue::<QUEUE_SIZE>(RX_QUEUE_IDX, &response);
+
+            // Expect a shutdown.
+            State::wait_until_queue_notified(&state, TX_QUEUE_IDX);
+            assert_eq!(
+                VirtioVsockHdr::read_from_bytes(
+                    state
+                        .lock()
+                        .unwrap()
+                        .read_from_queue::<QUEUE_SIZE>(TX_QUEUE_IDX)
+                        .as_slice()
+                )
+                .unwrap(),
+                VirtioVsockHdr {
+                    op: VirtioVsockOp::Shutdown.into(),
+                    src_cid: guest_cid.into(),
+                    dst_cid: host_cid.into(),
+                    src_port: guest_port.into(),
+                    dst_port: host_port.into(),
+                    len: 0.into(),
+                    socket_type: SocketType::Stream.into(),
+                    flags: (StreamShutdown::SEND | StreamShutdown::RECEIVE).into(),
+                    buf_alloc: 1024.into(),
+                    fwd_cnt: (hello_from_host.len() as u32).into(),
+                }
+            );
+        });
+
+        socket.connect(host_address, guest_port).unwrap();
+        assert_eq!(
+            socket.wait_for_event().unwrap(),
+            VsockEvent {
+                source: host_address,
+                destination: VsockAddr {
+                    cid: guest_cid,
+                    port: guest_port,
+                },
+                event_type: VsockEventType::Connected,
+                buffer_status: VsockBufferStatus {
+                    buffer_allocation: 50,
+                    forward_count: 0,
+                },
+            }
+        );
+        println!("Guest sending");
+        socket
+            .send(host_address, guest_port, "Hello from guest".as_bytes())
+            .unwrap();
+        println!("Guest waiting to receive.");
+        assert_eq!(
+            socket.wait_for_event().unwrap(),
+            VsockEvent {
+                source: host_address,
+                destination: VsockAddr {
+                    cid: guest_cid,
+                    port: guest_port,
+                },
+                event_type: VsockEventType::Received {
+                    length: hello_from_host.len()
+                },
+                buffer_status: VsockBufferStatus {
+                    buffer_allocation: 50,
+                    forward_count: hello_from_guest.len() as u32,
+                },
+            }
+        );
+        println!("Guest getting received data.");
+        let mut buffer = [0u8; 64];
+        assert_eq!(
+            socket.recv(host_address, guest_port, &mut buffer).unwrap(),
+            hello_from_host.len()
+        );
+        assert_eq!(
+            &buffer[0..hello_from_host.len()],
+            hello_from_host.as_bytes()
+        );
+        socket.shutdown(host_address, guest_port).unwrap();
+
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn incoming_connection() {
+        let host_cid = 2;
+        let guest_cid = 66;
+        let host_port = 1234;
+        let guest_port = 4321;
+        let wrong_guest_port = 4444;
+        let host_address = VsockAddr {
+            cid: host_cid,
+            port: host_port,
+        };
+
+        let mut config_space = VirtioVsockConfig {
+            guest_cid_low: ReadOnly::new(66),
+            guest_cid_high: ReadOnly::new(0),
+        };
+        let state = Arc::new(Mutex::new(State {
+            queues: vec![
+                QueueStatus::default(),
+                QueueStatus::default(),
+                QueueStatus::default(),
+            ],
+            ..Default::default()
+        }));
+        let transport = FakeTransport {
+            device_type: DeviceType::Socket,
+            max_queue_size: 32,
+            device_features: 0,
+            config_space: NonNull::from(&mut config_space),
+            state: state.clone(),
+        };
+        let mut socket = VsockConnectionManager::new(
+            VirtIOSocket::<FakeHal, FakeTransport<VirtioVsockConfig>>::new(transport).unwrap(),
+        );
+
+        socket.listen(guest_port);
+
+        // Start a thread to simulate the device.
+        let handle = thread::spawn(move || {
+            // Send a connection request for a port the guest isn't listening on.
+            println!("Host sending connection request to wrong port");
+            state.lock().unwrap().write_to_queue::<QUEUE_SIZE>(
+                RX_QUEUE_IDX,
+                VirtioVsockHdr {
+                    op: VirtioVsockOp::Request.into(),
+                    src_cid: host_cid.into(),
+                    dst_cid: guest_cid.into(),
+                    src_port: host_port.into(),
+                    dst_port: wrong_guest_port.into(),
+                    len: 0.into(),
+                    socket_type: SocketType::Stream.into(),
+                    flags: 0.into(),
+                    buf_alloc: 50.into(),
+                    fwd_cnt: 0.into(),
+                }
+                .as_bytes(),
+            );
+
+            // Expect a rejection.
+            println!("Host waiting for rejection");
+            State::wait_until_queue_notified(&state, TX_QUEUE_IDX);
+            assert_eq!(
+                VirtioVsockHdr::read_from_bytes(
+                    state
+                        .lock()
+                        .unwrap()
+                        .read_from_queue::<QUEUE_SIZE>(TX_QUEUE_IDX)
+                        .as_slice()
+                )
+                .unwrap(),
+                VirtioVsockHdr {
+                    op: VirtioVsockOp::Rst.into(),
+                    src_cid: guest_cid.into(),
+                    dst_cid: host_cid.into(),
+                    src_port: wrong_guest_port.into(),
+                    dst_port: host_port.into(),
+                    len: 0.into(),
+                    socket_type: SocketType::Stream.into(),
+                    flags: 0.into(),
+                    buf_alloc: 1024.into(),
+                    fwd_cnt: 0.into(),
+                }
+            );
+
+            // Send a connection request for a port the guest is listening on.
+            println!("Host sending connection request to right port");
+            state.lock().unwrap().write_to_queue::<QUEUE_SIZE>(
+                RX_QUEUE_IDX,
+                VirtioVsockHdr {
+                    op: VirtioVsockOp::Request.into(),
+                    src_cid: host_cid.into(),
+                    dst_cid: guest_cid.into(),
+                    src_port: host_port.into(),
+                    dst_port: guest_port.into(),
+                    len: 0.into(),
+                    socket_type: SocketType::Stream.into(),
+                    flags: 0.into(),
+                    buf_alloc: 50.into(),
+                    fwd_cnt: 0.into(),
+                }
+                .as_bytes(),
+            );
+
+            // Expect a response.
+            println!("Host waiting for response");
+            State::wait_until_queue_notified(&state, TX_QUEUE_IDX);
+            assert_eq!(
+                VirtioVsockHdr::read_from_bytes(
+                    state
+                        .lock()
+                        .unwrap()
+                        .read_from_queue::<QUEUE_SIZE>(TX_QUEUE_IDX)
+                        .as_slice()
+                )
+                .unwrap(),
+                VirtioVsockHdr {
+                    op: VirtioVsockOp::Response.into(),
+                    src_cid: guest_cid.into(),
+                    dst_cid: host_cid.into(),
+                    src_port: guest_port.into(),
+                    dst_port: host_port.into(),
+                    len: 0.into(),
+                    socket_type: SocketType::Stream.into(),
+                    flags: 0.into(),
+                    buf_alloc: 1024.into(),
+                    fwd_cnt: 0.into(),
+                }
+            );
+
+            println!("Host finished");
+        });
+
+        // Expect an incoming connection.
+        println!("Guest expecting incoming connection.");
+        assert_eq!(
+            socket.wait_for_event().unwrap(),
+            VsockEvent {
+                source: host_address,
+                destination: VsockAddr {
+                    cid: guest_cid,
+                    port: guest_port,
+                },
+                event_type: VsockEventType::ConnectionRequest,
+                buffer_status: VsockBufferStatus {
+                    buffer_allocation: 50,
+                    forward_count: 0,
+                },
+            }
+        );
+
+        handle.join().unwrap();
+    }
+}

--- a/virtio-drivers/src/device/socket/connectionmanager.rs
+++ b/virtio-drivers/src/device/socket/connectionmanager.rs
@@ -121,6 +121,17 @@ impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize>
         self.driver.guest_cid()
     }
 
+    /// Returns the status of a connection
+    pub fn get_connection_status(
+        &mut self,
+        destination: VsockAddr,
+        src_port: u32,
+    ) -> Result<ConnectionStatus> {
+        let (_, connection) = get_connection(&mut self.connections, destination, src_port)?;
+
+        Ok(connection.status)
+    }
+
     /// Allows incoming connections on the given port number.
     pub fn listen(&mut self, port: u32) {
         if !self.listening_ports.contains(&port) {

--- a/virtio-drivers/src/device/socket/connectionmanager.rs
+++ b/virtio-drivers/src/device/socket/connectionmanager.rs
@@ -54,10 +54,28 @@ pub struct VsockConnectionManager<
     listening_ports: Vec<u32>,
 }
 
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+/// Enum for the status of a connection
+pub enum ConnectionStatus {
+    /// new socket
+    New,
+    /// listening
+    Listen,
+    /// connection that has not been ack'd by the other peer
+    Connecting,
+    /// connected
+    Connected,
+    /// sent or received a shutdown
+    Closing,
+    /// closed
+    Close,
+}
+
 #[derive(Debug)]
 struct Connection {
     info: ConnectionInfo,
     buffer: RingBuffer,
+    status: ConnectionStatus,
     /// The peer sent a SHUTDOWN request, but we haven't yet responded with a RST because there is
     /// still data in the buffer.
     peer_requested_shutdown: bool,
@@ -70,6 +88,7 @@ impl Connection {
         Self {
             info,
             buffer: RingBuffer::new(buffer_capacity.try_into().unwrap()),
+            status: ConnectionStatus::New,
             peer_requested_shutdown: false,
         }
     }
@@ -126,10 +145,11 @@ impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize>
             return Err(SocketError::ConnectionExists.into());
         }
 
-        let new_connection =
+        let mut new_connection =
             Connection::new(destination, src_port, self.per_connection_buffer_capacity);
 
         self.driver.connect(&new_connection.info)?;
+        new_connection.status = ConnectionStatus::Connecting;
         debug!("Connection requested: {:?}", new_connection.info);
         self.connections.push(new_connection);
         Ok(())
@@ -138,6 +158,9 @@ impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize>
     /// Sends the buffer to the destination.
     pub fn send(&mut self, destination: VsockAddr, src_port: u32, buffer: &[u8]) -> Result {
         let (_, connection) = get_connection(&mut self.connections, destination, src_port)?;
+        if connection.status != ConnectionStatus::Connected {
+            return Err(SocketError::NotConnected.into());
+        }
 
         self.driver.send(buffer, &mut connection.info)
     }
@@ -167,7 +190,9 @@ impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize>
                     event.destination.port,
                     per_connection_buffer_capacity,
                 ));
-                connections.last_mut().unwrap()
+                let connection = connections.last_mut().unwrap();
+                connection.status = ConnectionStatus::Connected;
+                connection
             } else {
                 return Ok(None);
             };
@@ -206,8 +231,12 @@ impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize>
                     return Ok(None);
                 }
             }
-            VsockEventType::Connected => {}
+            VsockEventType::Connected => {
+                connection.status = ConnectionStatus::Connected;
+            }
             VsockEventType::Disconnected { reason } => {
+                connection.status = ConnectionStatus::Closing;
+
                 // Wait until client reads all data before removing connection.
                 if connection.buffer.is_empty() {
                     if reason == DisconnectReason::Shutdown {
@@ -237,6 +266,10 @@ impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize>
     pub fn recv(&mut self, peer: VsockAddr, src_port: u32, buffer: &mut [u8]) -> Result<usize> {
         let (connection_index, connection) = get_connection(&mut self.connections, peer, src_port)?;
 
+        if connection.status != ConnectionStatus::Connected {
+            return Err(SocketError::NotConnected.into());
+        }
+
         // Copy from ring buffer
         let bytes_read = connection.buffer.drain(buffer);
 
@@ -258,12 +291,20 @@ impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize>
     /// contain any data.
     pub fn recv_buffer_available_bytes(&mut self, peer: VsockAddr, src_port: u32) -> Result<usize> {
         let (_, connection) = get_connection(&mut self.connections, peer, src_port)?;
+        if connection.status != ConnectionStatus::Connected {
+            return Err(SocketError::NotConnected.into());
+        }
+
         Ok(connection.buffer.used())
     }
 
     /// Sends a credit update to the given peer.
     pub fn update_credit(&mut self, peer: VsockAddr, src_port: u32) -> Result {
         let (_, connection) = get_connection(&mut self.connections, peer, src_port)?;
+        if connection.status != ConnectionStatus::Connected {
+            return Err(SocketError::NotConnected.into());
+        }
+
         self.driver.credit_update(&connection.info)
     }
 
@@ -287,6 +328,11 @@ impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize>
     pub fn shutdown(&mut self, destination: VsockAddr, src_port: u32) -> Result {
         let (_, connection) = get_connection(&mut self.connections, destination, src_port)?;
 
+        if connection.status != ConnectionStatus::Connected {
+            return Err(SocketError::NotConnected.into());
+        }
+
+        connection.status = ConnectionStatus::Closing;
         self.driver.shutdown(&connection.info)
     }
 

--- a/virtio-drivers/src/device/socket/error.rs
+++ b/virtio-drivers/src/device/socket/error.rs
@@ -1,0 +1,61 @@
+//! This module contain the error from the VirtIO socket driver.
+
+use core::{fmt, result};
+
+/// The error type of VirtIO socket driver.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum SocketError {
+    /// There is an existing connection.
+    ConnectionExists,
+    /// The device is not connected to any peer.
+    NotConnected,
+    /// Peer socket is shutdown.
+    PeerSocketShutdown,
+    /// The given buffer is shorter than expected.
+    BufferTooShort,
+    /// The given buffer for output is shorter than expected.
+    OutputBufferTooShort(usize),
+    /// The given buffer has exceeded the maximum buffer size.
+    BufferTooLong(usize, usize),
+    /// Unknown operation.
+    UnknownOperation(u16),
+    /// Invalid operation,
+    InvalidOperation,
+    /// Invalid number.
+    InvalidNumber,
+    /// Unexpected data in packet.
+    UnexpectedDataInPacket,
+    /// Peer has insufficient buffer space, try again later.
+    InsufficientBufferSpaceInPeer,
+    /// Recycled a wrong buffer.
+    RecycledWrongBuffer,
+}
+
+impl fmt::Display for SocketError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::ConnectionExists => write!(
+                f,
+                "There is an existing connection. Please close the current connection before attempting to connect again."),
+            Self::NotConnected => write!(f, "The device is not connected to any peer. Please connect it to a peer first."),
+            Self::PeerSocketShutdown => write!(f, "The peer socket is shutdown."),
+            Self::BufferTooShort => write!(f, "The given buffer is shorter than expected"),
+            Self::BufferTooLong(actual, max) => {
+                write!(f, "The given buffer length '{actual}' has exceeded the maximum allowed buffer length '{max}'")
+            }
+            Self::OutputBufferTooShort(expected) => {
+                write!(f, "The given output buffer is too short. '{expected}' bytes is needed for the output buffer.")
+            }
+            Self::UnknownOperation(op) => {
+                write!(f, "The operation code '{op}' is unknown")
+            }
+            Self::InvalidOperation => write!(f, "Invalid operation"),
+            Self::InvalidNumber => write!(f, "Invalid number"),
+            Self::UnexpectedDataInPacket => write!(f, "No data is expected in the packet"),
+            Self::InsufficientBufferSpaceInPeer => write!(f, "Peer has insufficient buffer space, try again later"),
+            Self::RecycledWrongBuffer => write!(f, "Recycled a wrong buffer"),
+        }
+    }
+}
+
+pub type Result<T> = result::Result<T, SocketError>;

--- a/virtio-drivers/src/device/socket/mod.rs
+++ b/virtio-drivers/src/device/socket/mod.rs
@@ -1,0 +1,26 @@
+//! Driver for VirtIO socket devices.
+//!
+//! To use the driver, you should first create a [`VirtIOSocket`] instance with your VirtIO
+//! transport, and then create a [`VsockConnectionManager`] wrapping it to keep track of
+//! connections. If you want to manage connections yourself you can use the `VirtIOSocket` directly
+//! for a lower-level interface.
+//!
+//! See [`VsockConnectionManager`] for a usage example.
+
+#[cfg(feature = "alloc")]
+mod connectionmanager;
+mod error;
+mod protocol;
+#[cfg(feature = "alloc")]
+mod vsock;
+
+#[cfg(feature = "alloc")]
+pub use connectionmanager::VsockConnectionManager;
+pub use error::SocketError;
+pub use protocol::{StreamShutdown, VsockAddr, VMADDR_CID_HOST};
+#[cfg(feature = "alloc")]
+pub use vsock::{ConnectionInfo, DisconnectReason, VirtIOSocket, VsockEvent, VsockEventType};
+
+/// The size in bytes of each buffer used in the RX virtqueue. This must be bigger than
+/// `size_of::<VirtioVsockHdr>()`.
+const DEFAULT_RX_BUFFER_SIZE: usize = 512;

--- a/virtio-drivers/src/device/socket/mod.rs
+++ b/virtio-drivers/src/device/socket/mod.rs
@@ -15,7 +15,7 @@ mod protocol;
 mod vsock;
 
 #[cfg(feature = "alloc")]
-pub use connectionmanager::VsockConnectionManager;
+pub use connectionmanager::{ConnectionStatus, VsockConnectionManager};
 pub use error::SocketError;
 pub use protocol::{StreamShutdown, VsockAddr, VMADDR_CID_HOST};
 #[cfg(feature = "alloc")]

--- a/virtio-drivers/src/device/socket/protocol.rs
+++ b/virtio-drivers/src/device/socket/protocol.rs
@@ -1,0 +1,233 @@
+//! This module defines the socket device protocol according to the virtio spec v1.1 5.10 Socket Device
+
+use super::error::{self, SocketError};
+use crate::volatile::ReadOnly;
+use bitflags::bitflags;
+use core::{
+    convert::{TryFrom, TryInto},
+    fmt,
+};
+use zerocopy::{
+    byteorder::{LittleEndian, U16, U32, U64},
+    FromBytes, Immutable, IntoBytes, KnownLayout,
+};
+
+/// Well-known CID for the host.
+pub const VMADDR_CID_HOST: u64 = 2;
+
+/// Currently only stream sockets are supported. type is 1 for stream socket types.
+#[derive(Copy, Clone, Debug)]
+#[repr(u16)]
+pub enum SocketType {
+    /// Stream sockets provide in-order, guaranteed, connection-oriented delivery without message boundaries.
+    Stream = 1,
+    /// seqpacket socket type introduced in virtio-v1.2.
+    SeqPacket = 2,
+}
+
+impl From<SocketType> for U16<LittleEndian> {
+    fn from(socket_type: SocketType) -> Self {
+        (socket_type as u16).into()
+    }
+}
+
+/// VirtioVsockConfig is the vsock device configuration space.
+#[repr(C)]
+pub struct VirtioVsockConfig {
+    /// The guest_cid field contains the guest’s context ID, which uniquely identifies
+    /// the device for its lifetime. The upper 32 bits of the CID are reserved and zeroed.
+    ///
+    /// According to virtio spec v1.1 2.4.1 Driver Requirements: Device Configuration Space,
+    /// drivers MUST NOT assume reads from fields greater than 32 bits wide are atomic.
+    /// So we need to split the u64 guest_cid into two parts.
+    pub guest_cid_low: ReadOnly<u32>,
+    pub guest_cid_high: ReadOnly<u32>,
+}
+
+/// The message header for data packets sent on the tx/rx queues
+#[repr(C, packed)]
+#[derive(Clone, Copy, Debug, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq)]
+pub struct VirtioVsockHdr {
+    pub src_cid: U64<LittleEndian>,
+    pub dst_cid: U64<LittleEndian>,
+    pub src_port: U32<LittleEndian>,
+    pub dst_port: U32<LittleEndian>,
+    pub len: U32<LittleEndian>,
+    pub socket_type: U16<LittleEndian>,
+    pub op: U16<LittleEndian>,
+    pub flags: U32<LittleEndian>,
+    /// Total receive buffer space for this socket. This includes both free and in-use buffers.
+    pub buf_alloc: U32<LittleEndian>,
+    /// Free-running bytes received counter.
+    pub fwd_cnt: U32<LittleEndian>,
+}
+
+impl Default for VirtioVsockHdr {
+    fn default() -> Self {
+        Self {
+            src_cid: 0.into(),
+            dst_cid: 0.into(),
+            src_port: 0.into(),
+            dst_port: 0.into(),
+            len: 0.into(),
+            socket_type: SocketType::Stream.into(),
+            op: 0.into(),
+            flags: 0.into(),
+            buf_alloc: 0.into(),
+            fwd_cnt: 0.into(),
+        }
+    }
+}
+
+impl VirtioVsockHdr {
+    /// Returns the length of the data.
+    pub fn len(&self) -> u32 {
+        u32::from(self.len)
+    }
+
+    pub fn op(&self) -> error::Result<VirtioVsockOp> {
+        self.op.try_into()
+    }
+
+    pub fn source(&self) -> VsockAddr {
+        VsockAddr {
+            cid: self.src_cid.get(),
+            port: self.src_port.get(),
+        }
+    }
+
+    pub fn destination(&self) -> VsockAddr {
+        VsockAddr {
+            cid: self.dst_cid.get(),
+            port: self.dst_port.get(),
+        }
+    }
+
+    pub fn check_data_is_empty(&self) -> error::Result<()> {
+        if self.len() == 0 {
+            Ok(())
+        } else {
+            Err(SocketError::UnexpectedDataInPacket)
+        }
+    }
+}
+
+/// Socket address.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct VsockAddr {
+    /// Context Identifier.
+    pub cid: u64,
+    /// Port number.
+    pub port: u32,
+}
+
+/// An event sent to the event queue
+#[derive(Copy, Clone, Debug, Default, IntoBytes, FromBytes, Immutable, KnownLayout)]
+#[repr(C)]
+pub struct VirtioVsockEvent {
+    // ID from the virtio_vsock_event_id struct in the virtio spec
+    pub id: U32<LittleEndian>,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(u16)]
+pub enum VirtioVsockOp {
+    Invalid = 0,
+
+    /* Connect operations */
+    Request = 1,
+    Response = 2,
+    Rst = 3,
+    Shutdown = 4,
+
+    /* To send payload */
+    Rw = 5,
+
+    /* Tell the peer our credit info */
+    CreditUpdate = 6,
+    /* Request the peer to send the credit info to us */
+    CreditRequest = 7,
+}
+
+impl From<VirtioVsockOp> for U16<LittleEndian> {
+    fn from(op: VirtioVsockOp) -> Self {
+        (op as u16).into()
+    }
+}
+
+impl TryFrom<U16<LittleEndian>> for VirtioVsockOp {
+    type Error = SocketError;
+
+    fn try_from(v: U16<LittleEndian>) -> Result<Self, Self::Error> {
+        let op = match u16::from(v) {
+            0 => Self::Invalid,
+            1 => Self::Request,
+            2 => Self::Response,
+            3 => Self::Rst,
+            4 => Self::Shutdown,
+            5 => Self::Rw,
+            6 => Self::CreditUpdate,
+            7 => Self::CreditRequest,
+            _ => return Err(SocketError::UnknownOperation(v.into())),
+        };
+        Ok(op)
+    }
+}
+
+impl fmt::Debug for VirtioVsockOp {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Invalid => write!(f, "VIRTIO_VSOCK_OP_INVALID"),
+            Self::Request => write!(f, "VIRTIO_VSOCK_OP_REQUEST"),
+            Self::Response => write!(f, "VIRTIO_VSOCK_OP_RESPONSE"),
+            Self::Rst => write!(f, "VIRTIO_VSOCK_OP_RST"),
+            Self::Shutdown => write!(f, "VIRTIO_VSOCK_OP_SHUTDOWN"),
+            Self::Rw => write!(f, "VIRTIO_VSOCK_OP_RW"),
+            Self::CreditUpdate => write!(f, "VIRTIO_VSOCK_OP_CREDIT_UPDATE"),
+            Self::CreditRequest => write!(f, "VIRTIO_VSOCK_OP_CREDIT_REQUEST"),
+        }
+    }
+}
+
+bitflags! {
+    #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+    pub(crate) struct Feature: u64 {
+        /// stream socket type is supported.
+        const STREAM = 1 << 0;
+        /// seqpacket socket type is supported.
+        const SEQ_PACKET = 1 << 1;
+
+        // device independent
+        const NOTIFY_ON_EMPTY       = 1 << 24; // legacy
+        const ANY_LAYOUT            = 1 << 27; // legacy
+        const RING_INDIRECT_DESC    = 1 << 28;
+        const RING_EVENT_IDX        = 1 << 29;
+        const UNUSED                = 1 << 30; // legacy
+        const VERSION_1             = 1 << 32; // detect legacy
+
+        // since virtio v1.1
+        const ACCESS_PLATFORM       = 1 << 33;
+        const RING_PACKED           = 1 << 34;
+        const IN_ORDER              = 1 << 35;
+        const ORDER_PLATFORM        = 1 << 36;
+        const SR_IOV                = 1 << 37;
+        const NOTIFICATION_DATA     = 1 << 38;
+    }
+}
+
+bitflags! {
+    /// Flags sent with a shutdown request to hint that the peer won't send or receive more data.
+    #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+    pub struct StreamShutdown: u32 {
+        /// The peer will not receive any more data.
+        const RECEIVE = 1 << 0;
+        /// The peer will not send any more data.
+        const SEND = 1 << 1;
+    }
+}
+
+impl From<StreamShutdown> for U32<LittleEndian> {
+    fn from(flags: StreamShutdown) -> Self {
+        flags.bits().into()
+    }
+}

--- a/virtio-drivers/src/device/socket/vsock.rs
+++ b/virtio-drivers/src/device/socket/vsock.rs
@@ -1,0 +1,502 @@
+//! Driver for VirtIO socket devices.
+#![deny(unsafe_op_in_unsafe_fn)]
+
+use super::error::SocketError;
+use super::protocol::{
+    Feature, StreamShutdown, VirtioVsockConfig, VirtioVsockHdr, VirtioVsockOp, VsockAddr,
+};
+use super::DEFAULT_RX_BUFFER_SIZE;
+use crate::hal::Hal;
+use crate::queue::{owning::OwningQueue, VirtQueue};
+use crate::transport::Transport;
+use crate::volatile::volread;
+use crate::Result;
+use core::mem::size_of;
+use log::debug;
+use zerocopy::{FromBytes, IntoBytes};
+
+pub(crate) const RX_QUEUE_IDX: u16 = 0;
+pub(crate) const TX_QUEUE_IDX: u16 = 1;
+const EVENT_QUEUE_IDX: u16 = 2;
+
+pub(crate) const QUEUE_SIZE: usize = 8;
+const SUPPORTED_FEATURES: Feature = Feature::RING_EVENT_IDX.union(Feature::RING_INDIRECT_DESC);
+
+/// Information about a particular vsock connection.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ConnectionInfo {
+    /// The address of the peer.
+    pub dst: VsockAddr,
+    /// The local port number associated with the connection.
+    pub src_port: u32,
+    /// The last `buf_alloc` value the peer sent to us, indicating how much receive buffer space in
+    /// bytes it has allocated for packet bodies.
+    peer_buf_alloc: u32,
+    /// The last `fwd_cnt` value the peer sent to us, indicating how many bytes of packet bodies it
+    /// has finished processing.
+    peer_fwd_cnt: u32,
+    /// The number of bytes of packet bodies which we have sent to the peer.
+    tx_cnt: u32,
+    /// The number of bytes of buffer space we have allocated to receive packet bodies from the
+    /// peer.
+    pub buf_alloc: u32,
+    /// The number of bytes of packet bodies which we have received from the peer and handled.
+    fwd_cnt: u32,
+    /// Whether we have recently requested credit from the peer.
+    ///
+    /// This is set to true when we send a `VIRTIO_VSOCK_OP_CREDIT_REQUEST`, and false when we
+    /// receive a `VIRTIO_VSOCK_OP_CREDIT_UPDATE`.
+    has_pending_credit_request: bool,
+}
+
+impl ConnectionInfo {
+    /// Creates a new `ConnectionInfo` for the given peer address and local port, and default values
+    /// for everything else.
+    pub fn new(destination: VsockAddr, src_port: u32) -> Self {
+        Self {
+            dst: destination,
+            src_port,
+            ..Default::default()
+        }
+    }
+
+    /// Updates this connection info with the peer buffer allocation and forwarded count from the
+    /// given event.
+    pub fn update_for_event(&mut self, event: &VsockEvent) {
+        self.peer_buf_alloc = event.buffer_status.buffer_allocation;
+        self.peer_fwd_cnt = event.buffer_status.forward_count;
+
+        if let VsockEventType::CreditUpdate = event.event_type {
+            self.has_pending_credit_request = false;
+        }
+    }
+
+    /// Increases the forwarded count recorded for this connection by the given number of bytes.
+    ///
+    /// This should be called once received data has been passed to the client, so there is buffer
+    /// space available for more.
+    pub fn done_forwarding(&mut self, length: usize) {
+        self.fwd_cnt += length as u32;
+    }
+
+    /// Returns the number of bytes of RX buffer space the peer has available to receive packet body
+    /// data from us.
+    fn peer_free(&self) -> u32 {
+        self.peer_buf_alloc - (self.tx_cnt - self.peer_fwd_cnt)
+    }
+
+    fn new_header(&self, src_cid: u64) -> VirtioVsockHdr {
+        VirtioVsockHdr {
+            src_cid: src_cid.into(),
+            dst_cid: self.dst.cid.into(),
+            src_port: self.src_port.into(),
+            dst_port: self.dst.port.into(),
+            buf_alloc: self.buf_alloc.into(),
+            fwd_cnt: self.fwd_cnt.into(),
+            ..Default::default()
+        }
+    }
+}
+
+/// An event received from a VirtIO socket device.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VsockEvent {
+    /// The source of the event, i.e. the peer who sent it.
+    pub source: VsockAddr,
+    /// The destination of the event, i.e. the CID and port on our side.
+    pub destination: VsockAddr,
+    /// The peer's buffer status for the connection.
+    pub buffer_status: VsockBufferStatus,
+    /// The type of event.
+    pub event_type: VsockEventType,
+}
+
+impl VsockEvent {
+    /// Returns whether the event matches the given connection.
+    pub fn matches_connection(&self, connection_info: &ConnectionInfo, guest_cid: u64) -> bool {
+        self.source == connection_info.dst
+            && self.destination.cid == guest_cid
+            && self.destination.port == connection_info.src_port
+    }
+
+    fn from_header(header: &VirtioVsockHdr) -> Result<Self> {
+        let op = header.op()?;
+        let buffer_status = VsockBufferStatus {
+            buffer_allocation: header.buf_alloc.into(),
+            forward_count: header.fwd_cnt.into(),
+        };
+        let source = header.source();
+        let destination = header.destination();
+
+        let event_type = match op {
+            VirtioVsockOp::Request => {
+                header.check_data_is_empty()?;
+                VsockEventType::ConnectionRequest
+            }
+            VirtioVsockOp::Response => {
+                header.check_data_is_empty()?;
+                VsockEventType::Connected
+            }
+            VirtioVsockOp::CreditUpdate => {
+                header.check_data_is_empty()?;
+                VsockEventType::CreditUpdate
+            }
+            VirtioVsockOp::Rst | VirtioVsockOp::Shutdown => {
+                header.check_data_is_empty()?;
+                debug!("Disconnected from the peer");
+                let reason = if op == VirtioVsockOp::Rst {
+                    DisconnectReason::Reset
+                } else {
+                    DisconnectReason::Shutdown
+                };
+                VsockEventType::Disconnected { reason }
+            }
+            VirtioVsockOp::Rw => VsockEventType::Received {
+                length: header.len() as usize,
+            },
+            VirtioVsockOp::CreditRequest => {
+                header.check_data_is_empty()?;
+                VsockEventType::CreditRequest
+            }
+            VirtioVsockOp::Invalid => return Err(SocketError::InvalidOperation.into()),
+        };
+
+        Ok(VsockEvent {
+            source,
+            destination,
+            buffer_status,
+            event_type,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VsockBufferStatus {
+    pub buffer_allocation: u32,
+    pub forward_count: u32,
+}
+
+/// The reason why a vsock connection was closed.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum DisconnectReason {
+    /// The peer has either closed the connection in response to our shutdown request, or forcibly
+    /// closed it of its own accord.
+    Reset,
+    /// The peer asked to shut down the connection.
+    Shutdown,
+}
+
+/// Details of the type of an event received from a VirtIO socket.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum VsockEventType {
+    /// The peer requests to establish a connection with us.
+    ConnectionRequest,
+    /// The connection was successfully established.
+    Connected,
+    /// The connection was closed.
+    Disconnected {
+        /// The reason for the disconnection.
+        reason: DisconnectReason,
+    },
+    /// Data was received on the connection.
+    Received {
+        /// The length of the data in bytes.
+        length: usize,
+    },
+    /// The peer requests us to send a credit update.
+    CreditRequest,
+    /// The peer just sent us a credit update with nothing else.
+    CreditUpdate,
+}
+
+/// Low-level driver for a VirtIO socket device.
+///
+/// You probably want to use [`VsockConnectionManager`](super::VsockConnectionManager) rather than
+/// using this directly.
+///
+/// `RX_BUFFER_SIZE` is the size in bytes of each buffer used in the RX virtqueue. This must be
+/// bigger than `size_of::<VirtioVsockHdr>()`.
+pub struct VirtIOSocket<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize = DEFAULT_RX_BUFFER_SIZE>
+{
+    transport: T,
+    /// Virtqueue to receive packets.
+    rx: OwningQueue<H, QUEUE_SIZE, RX_BUFFER_SIZE>,
+    tx: VirtQueue<H, { QUEUE_SIZE }>,
+    /// Virtqueue to receive events from the device.
+    event: VirtQueue<H, { QUEUE_SIZE }>,
+    /// The guest_cid field contains the guest’s context ID, which uniquely identifies
+    /// the device for its lifetime. The upper 32 bits of the CID are reserved and zeroed.
+    guest_cid: u64,
+}
+
+impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize> Drop
+    for VirtIOSocket<H, T, RX_BUFFER_SIZE>
+{
+    fn drop(&mut self) {
+        // Clear any pointers pointing to DMA regions, so the device doesn't try to access them
+        // after they have been freed.
+        self.transport.queue_unset(RX_QUEUE_IDX);
+        self.transport.queue_unset(TX_QUEUE_IDX);
+        self.transport.queue_unset(EVENT_QUEUE_IDX);
+    }
+}
+
+impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize> VirtIOSocket<H, T, RX_BUFFER_SIZE> {
+    /// Create a new VirtIO Vsock driver.
+    pub fn new(mut transport: T) -> Result<Self> {
+        assert!(RX_BUFFER_SIZE > size_of::<VirtioVsockHdr>());
+
+        let negotiated_features = transport.begin_init(SUPPORTED_FEATURES);
+
+        let config = transport.config_space::<VirtioVsockConfig>()?;
+        debug!("config: {:?}", config);
+        // Safe because config is a valid pointer to the device configuration space.
+        let guest_cid = unsafe {
+            volread!(H, config, guest_cid_low) as u64
+                | (volread!(H, config, guest_cid_high) as u64) << 32
+        };
+        debug!("guest cid: {guest_cid:?}");
+
+        let rx = VirtQueue::new(
+            &mut transport,
+            RX_QUEUE_IDX,
+            negotiated_features.contains(Feature::RING_INDIRECT_DESC),
+            negotiated_features.contains(Feature::RING_EVENT_IDX),
+        )?;
+        let tx = VirtQueue::new(
+            &mut transport,
+            TX_QUEUE_IDX,
+            negotiated_features.contains(Feature::RING_INDIRECT_DESC),
+            negotiated_features.contains(Feature::RING_EVENT_IDX),
+        )?;
+        let event = VirtQueue::new(
+            &mut transport,
+            EVENT_QUEUE_IDX,
+            negotiated_features.contains(Feature::RING_INDIRECT_DESC),
+            negotiated_features.contains(Feature::RING_EVENT_IDX),
+        )?;
+
+        let rx = OwningQueue::new(rx)?;
+
+        transport.finish_init();
+        if rx.should_notify() {
+            transport.notify(RX_QUEUE_IDX);
+        }
+
+        Ok(Self {
+            transport,
+            rx,
+            tx,
+            event,
+            guest_cid,
+        })
+    }
+
+    /// Returns the CID which has been assigned to this guest.
+    pub fn guest_cid(&self) -> u64 {
+        self.guest_cid
+    }
+
+    /// Sends a request to connect to the given destination.
+    ///
+    /// This returns as soon as the request is sent; you should wait until `poll` returns a
+    /// `VsockEventType::Connected` event indicating that the peer has accepted the connection
+    /// before sending data.
+    pub fn connect(&mut self, connection_info: &ConnectionInfo) -> Result {
+        let header = VirtioVsockHdr {
+            op: VirtioVsockOp::Request.into(),
+            ..connection_info.new_header(self.guest_cid)
+        };
+        // Sends a header only packet to the TX queue to connect the device to the listening socket
+        // at the given destination.
+        self.send_packet_to_tx_queue(&header, &[])
+    }
+
+    /// Accepts the given connection from a peer.
+    pub fn accept(&mut self, connection_info: &ConnectionInfo) -> Result {
+        let header = VirtioVsockHdr {
+            op: VirtioVsockOp::Response.into(),
+            ..connection_info.new_header(self.guest_cid)
+        };
+        self.send_packet_to_tx_queue(&header, &[])
+    }
+
+    /// Requests the peer to send us a credit update for the given connection.
+    fn request_credit(&mut self, connection_info: &ConnectionInfo) -> Result {
+        let header = VirtioVsockHdr {
+            op: VirtioVsockOp::CreditRequest.into(),
+            ..connection_info.new_header(self.guest_cid)
+        };
+        self.send_packet_to_tx_queue(&header, &[])
+    }
+
+    /// Sends the buffer to the destination.
+    pub fn send(&mut self, buffer: &[u8], connection_info: &mut ConnectionInfo) -> Result {
+        self.check_peer_buffer_is_sufficient(connection_info, buffer.len())?;
+
+        let len = buffer.len() as u32;
+        let header = VirtioVsockHdr {
+            op: VirtioVsockOp::Rw.into(),
+            len: len.into(),
+            ..connection_info.new_header(self.guest_cid)
+        };
+        connection_info.tx_cnt += len;
+        self.send_packet_to_tx_queue(&header, buffer)
+    }
+
+    fn check_peer_buffer_is_sufficient(
+        &mut self,
+        connection_info: &mut ConnectionInfo,
+        buffer_len: usize,
+    ) -> Result {
+        if connection_info.peer_free() as usize >= buffer_len {
+            Ok(())
+        } else {
+            // Request an update of the cached peer credit, if we haven't already done so, and tell
+            // the caller to try again later.
+            if !connection_info.has_pending_credit_request {
+                self.request_credit(connection_info)?;
+                connection_info.has_pending_credit_request = true;
+            }
+            Err(SocketError::InsufficientBufferSpaceInPeer.into())
+        }
+    }
+
+    /// Tells the peer how much buffer space we have to receive data.
+    pub fn credit_update(&mut self, connection_info: &ConnectionInfo) -> Result {
+        let header = VirtioVsockHdr {
+            op: VirtioVsockOp::CreditUpdate.into(),
+            ..connection_info.new_header(self.guest_cid)
+        };
+        self.send_packet_to_tx_queue(&header, &[])
+    }
+
+    /// Polls the RX virtqueue for the next event, and calls the given handler function to handle
+    /// it.
+    pub fn poll(
+        &mut self,
+        handler: impl FnOnce(VsockEvent, &[u8]) -> Result<Option<VsockEvent>>,
+    ) -> Result<Option<VsockEvent>> {
+        self.rx.poll(&mut self.transport, |buffer| {
+            let (header, body) = read_header_and_body(buffer)?;
+            VsockEvent::from_header(&header).and_then(|event| handler(event, body))
+        })
+    }
+
+    /// Requests to shut down the connection cleanly, sending hints about whether we will send or
+    /// receive more data.
+    ///
+    /// This returns as soon as the request is sent; you should wait until `poll` returns a
+    /// `VsockEventType::Disconnected` event if you want to know that the peer has acknowledged the
+    /// shutdown.
+    pub fn shutdown_with_hints(
+        &mut self,
+        connection_info: &ConnectionInfo,
+        hints: StreamShutdown,
+    ) -> Result {
+        let header = VirtioVsockHdr {
+            op: VirtioVsockOp::Shutdown.into(),
+            flags: hints.into(),
+            ..connection_info.new_header(self.guest_cid)
+        };
+        self.send_packet_to_tx_queue(&header, &[])
+    }
+
+    /// Requests to shut down the connection cleanly, telling the peer that we won't send or receive
+    /// any more data.
+    ///
+    /// This returns as soon as the request is sent; you should wait until `poll` returns a
+    /// `VsockEventType::Disconnected` event if you want to know that the peer has acknowledged the
+    /// shutdown.
+    pub fn shutdown(&mut self, connection_info: &ConnectionInfo) -> Result {
+        self.shutdown_with_hints(
+            connection_info,
+            StreamShutdown::SEND | StreamShutdown::RECEIVE,
+        )
+    }
+
+    /// Forcibly closes the connection without waiting for the peer.
+    pub fn force_close(&mut self, connection_info: &ConnectionInfo) -> Result {
+        let header = VirtioVsockHdr {
+            op: VirtioVsockOp::Rst.into(),
+            ..connection_info.new_header(self.guest_cid)
+        };
+        self.send_packet_to_tx_queue(&header, &[])?;
+        Ok(())
+    }
+
+    fn send_packet_to_tx_queue(&mut self, header: &VirtioVsockHdr, buffer: &[u8]) -> Result {
+        let _len = if buffer.is_empty() {
+            self.tx
+                .add_notify_wait_pop(&[header.as_bytes()], &mut [], &mut self.transport)?
+        } else {
+            self.tx.add_notify_wait_pop(
+                &[header.as_bytes(), buffer],
+                &mut [],
+                &mut self.transport,
+            )?
+        };
+        Ok(())
+    }
+}
+
+fn read_header_and_body(buffer: &[u8]) -> Result<(VirtioVsockHdr, &[u8])> {
+    // This could fail if the device returns a buffer used length shorter than the header size.
+    let header = VirtioVsockHdr::read_from_prefix(buffer)
+        .map_err(|_| SocketError::BufferTooShort)?
+        .0;
+    let body_length = header.len() as usize;
+
+    // This could fail if the device returns an unreasonably long body length.
+    let data_end = size_of::<VirtioVsockHdr>()
+        .checked_add(body_length)
+        .ok_or(SocketError::InvalidNumber)?;
+    // This could fail if the device returns a body length longer than buffer used length it
+    // returned.
+    let data = buffer
+        .get(size_of::<VirtioVsockHdr>()..data_end)
+        .ok_or(SocketError::BufferTooShort)?;
+    Ok((header, data))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        hal::fake::FakeHal,
+        transport::{
+            fake::{FakeTransport, QueueStatus, State},
+            DeviceType,
+        },
+        volatile::ReadOnly,
+    };
+    use alloc::{sync::Arc, vec};
+    use core::ptr::NonNull;
+    use std::sync::Mutex;
+
+    #[test]
+    fn config() {
+        let mut config_space = VirtioVsockConfig {
+            guest_cid_low: ReadOnly::new(66),
+            guest_cid_high: ReadOnly::new(0),
+        };
+        let state = Arc::new(Mutex::new(State {
+            queues: vec![
+                QueueStatus::default(),
+                QueueStatus::default(),
+                QueueStatus::default(),
+            ],
+            ..Default::default()
+        }));
+        let transport = FakeTransport {
+            device_type: DeviceType::Socket,
+            max_queue_size: 32,
+            device_features: 0,
+            config_space: NonNull::from(&mut config_space),
+            state: state.clone(),
+        };
+        let socket =
+            VirtIOSocket::<FakeHal, FakeTransport<VirtioVsockConfig>>::new(transport).unwrap();
+        assert_eq!(socket.guest_cid(), 0x00_0000_0042);
+    }
+}

--- a/virtio-drivers/src/embedded_io.rs
+++ b/virtio-drivers/src/embedded_io.rs
@@ -1,0 +1,35 @@
+//! Implementation of `embedded-io::Error' trait for `Error`.
+
+use crate::{device::socket::SocketError, Error};
+use embedded_io::ErrorKind;
+
+impl embedded_io::Error for Error {
+    fn kind(&self) -> ErrorKind {
+        match self {
+            Error::InvalidParam => ErrorKind::InvalidInput,
+            Error::DmaError => ErrorKind::OutOfMemory,
+            Error::Unsupported => ErrorKind::Unsupported,
+            Error::SocketDeviceError(e) => match e {
+                &SocketError::ConnectionExists => ErrorKind::AddrInUse,
+                SocketError::NotConnected => ErrorKind::NotConnected,
+                SocketError::PeerSocketShutdown => ErrorKind::ConnectionAborted,
+                SocketError::BufferTooShort => ErrorKind::InvalidInput,
+                SocketError::OutputBufferTooShort(_) => ErrorKind::InvalidInput,
+                SocketError::BufferTooLong(_, _) => ErrorKind::InvalidInput,
+                SocketError::InsufficientBufferSpaceInPeer => ErrorKind::WriteZero,
+                SocketError::UnknownOperation(_)
+                | SocketError::InvalidOperation
+                | SocketError::InvalidNumber
+                | SocketError::UnexpectedDataInPacket
+                | SocketError::RecycledWrongBuffer => ErrorKind::Other,
+            },
+            Error::QueueFull
+            | Error::NotReady
+            | Error::WrongToken
+            | Error::AlreadyUsed
+            | Error::IoError
+            | Error::ConfigSpaceTooSmall
+            | Error::ConfigSpaceMissing => ErrorKind::Other,
+        }
+    }
+}

--- a/virtio-drivers/src/lib.rs
+++ b/virtio-drivers/src/lib.rs
@@ -21,6 +21,8 @@
 extern crate alloc;
 
 pub mod device;
+#[cfg(feature = "embedded-io")]
+mod embedded_io;
 mod hal;
 mod queue;
 pub mod transport;
@@ -62,6 +64,8 @@ pub enum Error {
     ConfigSpaceTooSmall,
     /// The device doesn't have any config space, but the driver expects some.
     ConfigSpaceMissing,
+    /// Error from the socket device.
+    SocketDeviceError(device::socket::SocketError),
 }
 
 #[cfg(feature = "alloc")]
@@ -95,7 +99,14 @@ impl Display for Error {
                     "The device doesn't have any config space, but the driver expects some"
                 )
             }
+            Self::SocketDeviceError(e) => write!(f, "Error from the socket device: {e:?}"),
         }
+    }
+}
+
+impl From<device::socket::SocketError> for Error {
+    fn from(e: device::socket::SocketError) -> Self {
+        Self::SocketDeviceError(e)
     }
 }
 


### PR DESCRIPTION
This PR introduces initial TLS client functionality and provides tool for testing client connections

### Dependency

This PR depends on the following PRs: vsock support and mmio native support . Those commits are included here for testing.

### Implementation Details

The implementation is based on [rustls crate](https://docs.rs/rustls/latest/rustls/), which in no_std environment requires to implement `CryptoProvider` and `TimeProvider`. Due to the absence of a trusted time source,`TimeProvider` is implemented as a fixed source of time. The `CryptoProvider` is based on the example provided in the rustls repository for the moment.

Rustls offers an unbuffered API for `no_std`, which requires the user to manage all the buffers for TLS and plaintext data. The struct `TlsBuffer` was created for this purpose.

Other struct were introduced to help manage the TLS connection. In particular, `TlsClient` provides a way to build a `TlsConnection`,  which handles handshake, sending and receiving of application records and closing the connection (The core of the functionalities).

The `CryptoProvider` needs a random number generator. Currently, the getrandom crate with feature `custom` is used, but this is just a temporary solution. 

### Compilation
To compile the feature `tls` needs to be enabled.

A CA certificate must be present at compilation time.
If the cert is missing, the `insert_ca_cert()` function in `kernel/build.rs` calls the script `scripts/gen_ca_server_certs.sh`, which generates signed certificates for both a CA and a server. It is possible to run `scripts/gen_ca_server_certs.sh` directly to run tests.

### Testing
Two example function are provided and are commented inside `kernel/src/svsm.rs`. Uncomment one to use it:
- `test_https()`: does a single GET request to a web server(i.e. `openssl s_server -WWW ...`) and then closes the connection. To simplify the testing process, a simple script automates certificates creation, compilation and launch of socat  and openssl on the host.
- `test_command_server()`: connects to a python server (`tls_command_server/command_server.py`) from which it can receive "commands" to execute. For the moment are simple messages. It stops when it receives the `EXIT` command.

#### Notes
- The scripts provides a certificate starting from the current date. The time provider needs to provide a date within the certificate validity.
- The stack size needed to be increased due to a double panic during the call of some rustls api. 
- To work with the examples, on the host run:
  - `socat -d -d   VSOCK-LISTEN:12345,reuseaddr,fork   TCP:localhost:4433`
  - start a server (openssl or the python server) 
 - `TlsConnection`, with read and write methods, provides support for a single TLS record at the time. So if an application record is divided in more TLS records more read or write operations are required.

--- 
For review: @stefano-garzarella @osteffenrh @luigix25