### PR TITLE
Introduce TLS client-side connection

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,6 +6,7 @@ rustflags = [
 	"-C", "linker-flavor=ld",
 	"--cfg", "aes_force_soft",
 	"--cfg", "polyval_force_soft",
+	"--cfg", "curve25519_dalek_backend=\"serial\"",
 ]
 
 [target.x86_64-unknown-linux-gnu]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,6 +561,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,6 +722,12 @@ dependencies = [
  "rand_core",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fnv"
@@ -1252,6 +1283,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "libaproxy"
 version = "0.1.0"
 dependencies = [
@@ -1287,6 +1327,12 @@ dependencies = [
  "cfg-if",
  "windows-targets 0.53.2",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libtcgtpm"
@@ -1393,10 +1439,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1405,6 +1488,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1464,6 +1548,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "p384"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1518,6 +1614,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1553,6 +1660,15 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy 0.8.26",
+]
 
 [[package]]
 name = "prettyplease"
@@ -1621,6 +1737,26 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
 
 [[package]]
 name = "rand_core"
@@ -1717,6 +1853,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core",
+ "sha2",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1735,6 +1906,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1878,6 +2082,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1945,21 +2155,31 @@ dependencies = [
  "cocoon-tpm-tpm2-interface",
  "cocoon-tpm-utils-common",
  "cpuarch",
+ "der",
+ "ecdsa",
  "elf",
  "gdbstub",
  "gdbstub_arch",
+ "getrandom 0.2.16",
+ "hmac",
  "igvm_defs",
  "intrusive-collections",
  "kbs-types",
  "libaproxy",
  "libtcgtpm",
  "log",
+ "p256",
  "packit",
+ "pkcs8",
+ "rand_core",
  "release",
+ "rsa",
  "rustc_version",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
+ "signature",
  "syscall",
  "test",
  "uuid",
@@ -1968,6 +2188,7 @@ dependencies = [
  "verus_stub",
  "virtio-drivers",
  "vstd",
+ "x25519-dalek",
  "zerocopy 0.8.26",
 ]
 
@@ -2229,6 +2450,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -2612,6 +2839,16 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core",
+]
 
 [[package]]
 name = "xbuild"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,18 @@ vstd = { git = "https://github.com/verus-lang/verus", rev ="6c66898", features =
 verify_proof = { path = "verify_proof", default-features = false  }
 verify_external = { path = "verify_external", default-features = false  }
 
+rustls = { version = "0.23.31", default-features = false }
+hmac = { version="0.12", default-features= false }
+ecdsa = { version = "0.16.8", default-features=false }
+der =  { version = "0.7", default-features = false  }
+p256 ={ version = "0.13.2", default-features = false }
+pkcs8 = {version = "0.10.2", default-features = false }
+rsa = { version = "0.9", default-features = false }
+signature = {version = "2", default-features = false }
+x25519-dalek =  {version = "2", default-features = false }
+getrandom = { version = "0.2", default-features = false }
+rand_core = { version = "0.6.4", default-features = false }
+
 [profile.release]
 panic = 'abort'
 

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -67,13 +67,26 @@ verify_proof = { workspace = true, optional = true}
 verify_external = { workspace = true, optional = true}
 verus_stub = { workspace = true }
 
+rustls = { workspace = true, optional = true }
+getrandom = { workspace = true, optional = true, features = ["custom"] }
+hmac = { workspace = true, optional = true }
+ecdsa = { workspace = true, optional = true, features = ["pem"] }
+der =  { workspace = true, optional = true, features = ["alloc"] }
+p256 = { workspace = true, optional = true, features = ["alloc", "ecdsa", "pkcs8"] }
+pkcs8 = { workspace = true, optional = true, features = ["alloc"] }
+rsa = { workspace = true, optional = true, features = ["sha2"] }
+signature = { workspace = true, optional = true }
+x25519-dalek =  { workspace = true, optional = true }
+rand_core = { workspace = true, optional = true, features= ["getrandom"] }
+
 [target."x86_64-unknown-none".dev-dependencies]
 test.workspace = true
 
 [features]
 attest = ["dep:aes", "dep:base64", "dep:cocoon-tpm-crypto", "dep:cocoon-tpm-tpm2-interface", "dep:cocoon-tpm-utils-common", "dep:kbs-types", "dep:libaproxy", "dep:serde", "dep:serde_json"]
 vsock = []
-
+tls = ["dep:rustls", "dep:getrandom", "vsock", "virtio-drivers", "rustcrypto"]
+rustcrypto = ["dep:hmac", "dep:ecdsa", "dep:der", "dep:p256", "dep:pkcs8", "dep:rsa", "dep:signature", "dep:x25519-dalek", "dep:rand_core","dep:aes"]
 default = []
 enable-gdb = ["dep:gdbstub", "dep:gdbstub_arch"]
 vtpm = ["dep:libtcgtpm"]

--- a/kernel/build.rs
+++ b/kernel/build.rs
@@ -40,6 +40,7 @@ fn main() {
     println!("cargo:rerun-if-changed=kernel/src/svsm.lds");
     println!("cargo:rerun-if-changed=build.rs");
     init_verify();
+    insert_ca_cert();
 }
 
 fn init_verify() {
@@ -55,5 +56,34 @@ fn init_verify() {
             "-Z unstable-options",
         ];
         println!("cargo:rustc-env=VERUS_ARGS={}", verus_args.join(" "));
+    }
+}
+
+fn insert_ca_cert() {
+    if cfg!(not(feature = "tls")) {
+        return;
+    }
+
+    let ca_cert_path = std::path::Path::new(std::env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("Failed to get parent directory")
+        .join("certificates")
+        .join("ca.der");
+    if ca_cert_path.exists() {
+        return;
+    }
+
+    let script_path = std::path::Path::new(std::env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("Failed to get parent directory")
+        .join("scripts")
+        .join("gen_ca_server_certs.sh");
+
+    let status = std::process::Command::new("sh")
+        .arg(&script_path)
+        .status()
+        .expect("Failed to execute process");
+    if !status.success() {
+        panic!("CA cert generation script failed");
     }
 }

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -31,6 +31,8 @@ use crate::sev::SevSnpError;
 use crate::syscall::ObjError;
 use crate::task::TaskError;
 use crate::tdx::TdxError;
+#[cfg(feature = "tls")]
+use crate::tls::error::TlsError;
 #[cfg(feature = "virtio-drivers")]
 use crate::virtio::VirtioError;
 #[cfg(feature = "vsock")]
@@ -134,6 +136,9 @@ pub enum SvsmError {
     /// Errors related to vsock.
     #[cfg(feature = "vsock")]
     Vsock(VsockError),
+    // Errors related to TLS.
+    #[cfg(feature = "tls")]
+    Tls(TlsError),
 }
 
 impl From<ElfError> for SvsmError {
@@ -177,6 +182,13 @@ impl From<BlockDeviceError> for SvsmError {
 impl From<VsockError> for SvsmError {
     fn from(err: VsockError) -> Self {
         Self::Vsock(err)
+    }
+}
+
+#[cfg(feature = "tls")]
+impl From<TlsError> for SvsmError {
+    fn from(err: TlsError) -> Self {
+        Self::Tls(err)
     }
 }
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -41,6 +41,8 @@ pub mod svsm_paging;
 pub mod syscall;
 pub mod task;
 pub mod tdx;
+#[cfg(feature = "tls")]
+pub mod tls;
 pub mod types;
 pub mod utils;
 #[cfg(feature = "virtio-drivers")]

--- a/kernel/src/mm/address_space.rs
+++ b/kernel/src/mm/address_space.rs
@@ -159,7 +159,7 @@ pub const SIZE_LEVEL1: usize = 1usize << ((9 * 1) + 12);
 pub const SIZE_LEVEL0: usize = 1usize << ((9 * 0) + 12);
 
 // Stack definitions
-pub const STACK_PAGES: usize = 8;
+pub const STACK_PAGES: usize = 16;
 pub const STACK_SIZE: usize = PAGE_SIZE * STACK_PAGES;
 pub const STACK_GUARD_SIZE: usize = STACK_SIZE;
 pub const STACK_TOTAL_SIZE: usize = STACK_SIZE + STACK_GUARD_SIZE;

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -397,6 +397,11 @@ pub fn svsm_main(cpu_index: usize) {
         // TLS library uses (for the moment) getrandom crate
         // This is not the final implementation, just a placeholder
         register_custom_getrandom!(custom_getrandom);
+        // Uncomment one of the following lines to run the corresponding test
+        use svsm::tls::examples::test_https;
+        test_https();
+        // use svsm::tls::examples::test_command_server;
+        // test_command_server();
     }
 
     // Start request processing on this CPU if required.

--- a/kernel/src/svsm.rs
+++ b/kernel/src/svsm.rs
@@ -63,6 +63,11 @@ use release::COCONUT_VERSION;
 #[cfg(feature = "attest")]
 use kbs_types::Tee;
 
+#[cfg(feature = "tls")]
+use getrandom::register_custom_getrandom;
+#[cfg(feature = "tls")]
+use svsm::tls::random::custom_getrandom;
+
 extern "C" {
     static bsp_stack: u8;
     static bsp_stack_end: u8;
@@ -383,6 +388,15 @@ pub fn svsm_main(cpu_index: usize) {
     match exec_user("/init", opendir("/").expect("Failed to find FS root")) {
         Ok(_) => (),
         Err(e) => log::info!("Failed to launch /init: {e:?}"),
+    }
+
+    #[cfg(feature = "tls")]
+    {
+        // Register the custom getrandom implementation for SVSM
+        // This is required for TLS to work
+        // TLS library uses (for the moment) getrandom crate
+        // This is not the final implementation, just a placeholder
+        register_custom_getrandom!(custom_getrandom);
     }
 
     // Start request processing on this CPU if required.

--- a/kernel/src/tls/buffer.rs
+++ b/kernel/src/tls/buffer.rs
@@ -1,0 +1,123 @@
+// Buffer management for TLS records
+extern crate alloc;
+use super::constant::{FIRST_LEN_BYTE_POS, HEADER_LEN, SECOND_LEN_BYTE_POS};
+use super::error::TlsError;
+use alloc::vec;
+use alloc::vec::Vec;
+
+/// A buffer structure to manage TLS records, allowing for efficient reading and writing
+/// of data while handling partial reads/writes and discarding processed data.
+#[derive(Debug)]
+pub struct TlsBuffer {
+    // The underlying byte buffer
+    buf: Vec<u8>,
+    // The first used (valid, non-discarded) byte in the buffer
+    head: usize,
+    // The first unused byte in the buffer
+    tail: usize,
+}
+
+// fixme: input buffer is different from output buffer
+// maybe we should have two different structs
+
+impl TlsBuffer {
+    /// Create a new [`TlsBuffer`] with the specified size
+    pub fn new(size: usize) -> Self {
+        Self {
+            buf: vec![0u8; size],
+            head: 0,
+            tail: 0,
+        }
+    }
+
+    /// Get a mutable reference to the currently used portion of the buffer
+    pub fn curr_used_buf_as_mut(&mut self) -> &mut [u8] {
+        &mut self.buf[self.head..self.tail]
+    }
+
+    /// Get a reference to the currently used portion of the buffer
+    pub fn curr_used_buf_as_ref(&self) -> &[u8] {
+        &self.buf[self.head..self.tail]
+    }
+
+    /// Get a mutable reference to the remaining (unused) portion of the buffer
+    pub fn remaining_buf_as_mut(&mut self) -> &mut [u8] {
+        &mut self.buf[self.tail..]
+    }
+
+    /// Get a reference to the remaining (unused) portion of the buffer of the specified size
+    pub fn mutable_slice_from_remaining(&mut self, size: usize) -> Result<&mut [u8], TlsError> {
+        if self.tail + size > self.buf.len() {
+            return Err(TlsError::BufferTooSmall);
+        }
+        Ok(&mut self.buf[self.tail..self.tail + size])
+    }
+
+    /// From the current position (tail), extract the length of the TLS record
+    /// by reading the appropriate bytes in the TLS header.
+    pub fn extract_record_len_from_current_position(&self) -> Result<usize, TlsError> {
+        if self.tail + HEADER_LEN > self.buf.len() {
+            return Err(TlsError::BufferTooSmall);
+        }
+        Ok(((self.buf[self.tail + SECOND_LEN_BYTE_POS] as usize) << 8)
+            | (self.buf[self.tail + FIRST_LEN_BYTE_POS] as usize))
+    }
+
+    /// Advance the tail pointer by `n` bytes, marking them as used
+    pub fn advance_used(&mut self, n: usize) -> Result<(), TlsError> {
+        if self.tail + n > self.buf.len() {
+            return Err(TlsError::BufferTooSmall);
+        }
+        self.tail += n;
+        Ok(())
+    }
+
+    /// Reset the buffer to an empty state, discarding all used data
+    pub fn reset_used(&mut self) {
+        self.head = 0;
+        self.tail = 0;
+    }
+
+    /// Ensure that there is enough space in the buffer for `needed` bytes.
+    /// Try to compact the buffer, i.e., discard unused data from the front.
+    /// Returns an error if the buffer is still too small.
+    pub fn ensure_space(&mut self, needed: usize) -> Result<(), TlsError> {
+        let remaining_space = self.buf.len() - self.tail;
+
+        if remaining_space >= needed {
+            return Ok(());
+        }
+
+        self.compact();
+
+        let remaining_space_after_compact = self.buf.len() - self.tail;
+        if remaining_space_after_compact < needed {
+            return Err(TlsError::BufferTooSmall);
+        }
+
+        Ok(())
+    }
+
+    /// Discard n bytes from the start of the used buffer.
+    pub fn move_head(&mut self, n: usize) {
+        self.head += n;
+        if self.head > self.tail {
+            self.head = self.tail; // Prevent discarding more than tail
+        }
+    }
+
+    /// Compact the buffer by moving the used data to the front and adjusting head and tail pointers
+    fn compact(&mut self) {
+        if self.head == 0 {
+            return;
+        }
+        log::info!(
+            "Compacting buffer, tail: {}, discarding: {}",
+            self.tail,
+            self.head
+        );
+        self.buf.copy_within(self.head..self.tail, 0);
+        self.tail -= self.head;
+        self.head = 0;
+    }
+}

--- a/kernel/src/tls/connection.rs
+++ b/kernel/src/tls/connection.rs
@@ -1,0 +1,423 @@
+//! This module is responsible for managing TLS connections.
+//! It uses rustls unbuffered API, which are suitable for no_std environments.
+//! The module provides a TlsClient struct to create and configure TLS connections,
+//! and a TlsConnection struct to manage individual TLS connections over VsockStream.
+//! The TlsConnection struct, thanks to the provided API, manages the TLS state machine,
+//! including handshake, reading and writing application data, and closing the connection.
+
+extern crate alloc;
+use alloc::sync::Arc;
+
+use super::buffer::TlsBuffer;
+use super::constant::{HEADER_LEN, IN_BUF_SIZE, OUT_BUF_SIZE};
+use super::crypto_provider::provider;
+use super::error::TlsError;
+use super::time_provider::FixedTimeProvider;
+
+use crate::error::SvsmError;
+use crate::io::{Read, Write};
+use crate::vsock::virtio_vsock::VsockStream;
+
+use rustls::client::{ClientConnectionData, UnbufferedClientConnection};
+use rustls::pki_types::{CertificateDer, DnsName, ServerName};
+use rustls::unbuffered::{
+    AppDataRecord, ConnectionState, EncodeTlsData, UnbufferedStatus, WriteTraffic,
+};
+use rustls::{ClientConfig, RootCertStore};
+
+/// The [`TlsClient`] struct is responsible for creating and configuring [`TlsConnection`] instances.
+#[derive(Debug)]
+pub struct TlsClient {
+    config: Arc<ClientConfig>,
+}
+
+impl TlsClient {
+    /// Create a new [`TlsClient`] with optional debug information
+    pub fn new(debug_info: bool) -> Self {
+        let config =
+            Self::create_client_config(debug_info).expect("Failed to create TLS client config");
+        Self { config }
+    }
+
+    /// Establish a TLS connection over a given [`VsockStream`]
+    pub fn connect(
+        &self,
+        sock: VsockStream,
+        server_name: &str,
+    ) -> Result<TlsConnection, SvsmError> {
+        let conn = UnbufferedClientConnection::new(
+            self.config.clone(),
+            Self::server_name_from_str(server_name)?,
+        )
+        .map_err(TlsError::from)?;
+        Ok(TlsConnection::new(sock, conn))
+    }
+
+    /// Create a TLS client configuration, which includes setting up root certificates, a time provider, and a crypto provider.
+    fn create_client_config(debug_info: bool) -> Result<Arc<ClientConfig>, TlsError> {
+        let crypto_provider = provider();
+        let time_provider = FixedTimeProvider::december_2025();
+
+        let mut root_store = RootCertStore::empty();
+
+        root_store.add(CertificateDer::from_slice(include_bytes!(
+            "../../../certificates/ca.der"
+        )))?;
+
+        let mut config =
+            ClientConfig::builder_with_details(Arc::new(crypto_provider), Arc::new(time_provider))
+                .with_protocol_versions(&[&rustls::version::TLS13])?
+                .with_root_certificates(root_store)
+                .with_no_client_auth();
+
+        if debug_info {
+            config.key_log = Arc::new(super::key_logger::MyKeyLogger);
+        }
+
+        Ok(Arc::new(config))
+    }
+
+    /// Convert a string to a [`ServerName`]
+    fn server_name_from_str(name: &str) -> Result<ServerName<'static>, TlsError> {
+        let dns = DnsName::try_from(name).map_err(|_| TlsError::InvalidDnsName)?;
+        Ok(ServerName::DnsName(dns.to_owned()))
+    }
+}
+
+/// The [`TlsConnection`] struct manages a TLS connection over a [`VsockStream`].
+/// It provides a way to manage all the TLS-related operations.
+pub struct TlsConnection {
+    conn: UnbufferedClientConnection,
+    sock: VsockStream,
+    in_buffer: TlsBuffer,
+    out_buffer: TlsBuffer,
+    status: ConnectionDetails,
+}
+
+impl TlsConnection {
+    /// Create a new [`TlsConnection`]
+    pub fn new(sock: VsockStream, conn: UnbufferedClientConnection) -> Self {
+        let in_buffer = TlsBuffer::new(IN_BUF_SIZE);
+        let out_buffer = TlsBuffer::new(OUT_BUF_SIZE);
+        let status = ConnectionDetails::new();
+        Self {
+            conn,
+            sock,
+            in_buffer,
+            out_buffer,
+            status,
+        }
+    }
+
+    /// Complete the TLS handshake
+    pub fn complete_handshake(&mut self) -> Result<(), SvsmError> {
+        while !self.status.handshake_complete && !self.status.connection_closed {
+            self.tls_state_machine_advance(TlsAction::Handshake)?;
+        }
+        Ok(())
+    }
+
+    /// Read a single TLS record and decrypt application data into the provided buffer
+    pub fn read_tls(&mut self, buf: &mut [u8]) -> Result<usize, SvsmError> {
+        let mut total_read = 0;
+        if self.status.connection_closed || self.status.peer_closed {
+            return Ok(0);
+        }
+        self.status.received_response = false; // reset for next read
+        while !self.status.received_response
+            && !self.status.connection_closed
+            && !self.status.peer_closed
+        {
+            self.tls_state_machine_advance(TlsAction::ReadRecord {
+                buffer: buf,
+                total_read: &mut total_read,
+            })?;
+        }
+        Ok(total_read)
+    }
+
+    /// Encrypt and send a single TLS record
+    pub fn write_tls(&mut self, data: &[u8]) -> Result<(), SvsmError> {
+        if self.status.connection_closed {
+            return Err(TlsError::ConnectionClosed.into());
+        }
+        self.tls_state_machine_advance(TlsAction::WriteRecord { buffer: data })?;
+        if !self.status.request_sent {
+            // should return 0?
+            return Err(TlsError::GenericError.into());
+        }
+        Ok(()) // should return buffer len?
+    }
+
+    /// Close the TLS connection
+    pub fn close_tls(&mut self) -> Result<(), SvsmError> {
+        while !self.status.connection_closed {
+            self.tls_state_machine_advance(TlsAction::CloseConnection)?;
+        }
+        Ok(())
+    }
+
+    /// Advance the TLS state machine based on the current connection state and the provided action
+    fn tls_state_machine_advance(&mut self, action: TlsAction<'_>) -> Result<(), SvsmError> {
+        // Process incoming TLS record and determine the next state
+        let UnbufferedStatus { discard, state } = self
+            .conn
+            .process_tls_records(self.in_buffer.curr_used_buf_as_mut());
+
+        match state.map_err(TlsError::from)? {
+            // ##################################################################
+            // Handshake states
+            // ##################################################################
+
+            // An handshake record needs to be encoded
+            ConnectionState::EncodeTlsData(mut encode_tls_data) => {
+                if TlsAction::Handshake != action {
+                    return Err(TlsError::UnexpectedState.into());
+                }
+
+                TlsConnection::prepare_handshake_record(
+                    &mut encode_tls_data,
+                    &mut self.out_buffer,
+                )?;
+                self.in_buffer.move_head(discard);
+            }
+
+            // The handshake record is ready to be transmitted
+            ConnectionState::TransmitTlsData(trasmit_tls_data) => {
+                if TlsAction::Handshake != action {
+                    return Err(TlsError::UnexpectedState.into());
+                }
+                TlsConnection::send_record_over_vsock(&mut self.sock, &mut self.out_buffer)?;
+                // Signal that the transmission is complete
+                trasmit_tls_data.done();
+                self.in_buffer.move_head(discard);
+                if !self.conn.is_handshaking() {
+                    self.status.handshake_complete = true;
+                }
+            }
+
+            // Waiting for a handshake record from the peer
+            ConnectionState::BlockedHandshake { .. } => {
+                if TlsAction::Handshake != action {
+                    return Err(TlsError::UnexpectedState.into());
+                }
+                self.in_buffer.move_head(discard);
+                self.recv_record_over_vsock()?;
+            }
+
+            // ##################################################################
+            // Application data states
+            // ##################################################################
+
+            // Ready to send application data, to close the connection, or to read data
+            ConnectionState::WriteTraffic(mut write_traffic) => {
+                if TlsAction::Handshake == action {
+                    return Err(TlsError::UnexpectedState.into());
+                }
+
+                if let TlsAction::WriteRecord { buffer } = action {
+                    TlsConnection::encrypt_data(&mut write_traffic, &mut self.out_buffer, buffer)?;
+                    TlsConnection::send_record_over_vsock(&mut self.sock, &mut self.out_buffer)?;
+                    self.status.request_sent = true;
+                    self.in_buffer.move_head(discard);
+                } else if TlsAction::CloseConnection == action && !self.status.our_side_closed {
+                    TlsConnection::prepare_queue_close_notify(
+                        &mut write_traffic,
+                        &mut self.out_buffer,
+                    )?;
+                    TlsConnection::send_record_over_vsock(&mut self.sock, &mut self.out_buffer)?;
+                    self.status.our_side_closed = true;
+                    self.in_buffer.move_head(discard);
+                } else {
+                    log::info!("Receiving record");
+                    self.in_buffer.move_head(discard);
+                    self.recv_record_over_vsock()?;
+                }
+            }
+
+            // Application data record ready to be read
+            ConnectionState::ReadTraffic(mut read_traffic) => {
+                let TlsAction::ReadRecord { buffer, total_read } = action else {
+                    return Err(TlsError::UnexpectedState.into());
+                };
+
+                let res = read_traffic
+                    .next_record()
+                    .ok_or(TlsError::GenericError)?
+                    .map_err(TlsError::from)?;
+
+                let mut total_discard = discard;
+
+                let AppDataRecord { discard, payload } = res;
+
+                total_discard += discard;
+
+                let payload_len = payload.len();
+                let to_copy = core::cmp::min(buffer.len(), payload_len);
+                buffer[..to_copy].copy_from_slice(&payload[..to_copy]);
+                self.in_buffer.move_head(total_discard);
+                self.status.received_response = true;
+                *total_read += to_copy;
+            }
+
+            // The peer sent a close_notify alert
+            ConnectionState::PeerClosed => {
+                log::info!("Peer closed the connection");
+                self.in_buffer.move_head(discard);
+                self.status.peer_closed = true;
+                // maybe call close_tls() here? What if I need to send more data?
+            }
+
+            // The connection is fully closed
+            ConnectionState::Closed => {
+                self.status.connection_closed = true;
+            }
+
+            _ => {
+                return Err(TlsError::UnexpectedState.into());
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Encrypt application data and store it in the out_buffer
+    fn encrypt_data(
+        write_traffic: &mut WriteTraffic<'_, ClientConnectionData>,
+        out_buffer: &mut TlsBuffer,
+        data: &[u8],
+    ) -> Result<(), TlsError> {
+        let bytes_written = write_traffic.encrypt(data, out_buffer.remaining_buf_as_mut())?;
+        out_buffer.advance_used(bytes_written)?;
+
+        Ok(())
+    }
+
+    /// Prepare a close_notify alert to be sent over the network. From this point on, no more data can be sent.
+    fn prepare_queue_close_notify(
+        write_traffic: &mut WriteTraffic<'_, ClientConnectionData>,
+        out_buffer: &mut TlsBuffer,
+    ) -> Result<(), TlsError> {
+        let bytes_written = write_traffic.queue_close_notify(out_buffer.remaining_buf_as_mut())?;
+        out_buffer.advance_used(bytes_written)?;
+        Ok(())
+    }
+
+    /// Prepare a TLS handshake record to be sent over the network based on the current handshake state
+    fn prepare_handshake_record(
+        encode_tls_data: &mut EncodeTlsData<'_, ClientConnectionData>,
+        out_buffer: &mut TlsBuffer,
+    ) -> Result<(), TlsError> {
+        let bytes_written = encode_tls_data.encode(out_buffer.remaining_buf_as_mut())?;
+        out_buffer.advance_used(bytes_written)?;
+        Ok(())
+    }
+
+    /// Send the contents of the out_buffer over the [`VsockStream`] and reset the buffer
+    fn send_record_over_vsock(
+        sock: &mut VsockStream,
+        out_buffer: &mut TlsBuffer,
+    ) -> Result<(), SvsmError> {
+        sock.write(out_buffer.curr_used_buf_as_ref())?;
+        out_buffer.reset_used();
+        Ok(())
+    }
+
+    /// Receive a TLS record from the [`VsockStream`] and store it in the in_buffer
+    fn recv_record_over_vsock(&mut self) -> Result<(), SvsmError> {
+        // First read the TLS record header to determine the payload length
+        // Then read the payload based on the length specified in the header
+
+        self.in_buffer.ensure_space(HEADER_LEN)?;
+
+        let read_bytes = self
+            .sock
+            .read(self.in_buffer.mutable_slice_from_remaining(HEADER_LEN)?)?;
+
+        if read_bytes != HEADER_LEN {
+            return Err(TlsError::IncompleteRead.into());
+        }
+
+        let payload_len = self.in_buffer.extract_record_len_from_current_position()?;
+        self.in_buffer.advance_used(HEADER_LEN)?;
+
+        self.in_buffer.ensure_space(payload_len)?;
+
+        let read_bytes = self
+            .sock
+            .read(self.in_buffer.mutable_slice_from_remaining(payload_len)?)?;
+
+        if read_bytes != payload_len {
+            return Err(TlsError::IncompleteRead.into());
+        }
+
+        self.in_buffer.advance_used(payload_len)?;
+
+        Ok(())
+    }
+}
+
+impl core::fmt::Debug for TlsConnection {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("TlsConnection")
+            .field("in_buffer", &self.in_buffer)
+            .field("out_buffer", &self.out_buffer)
+            .field("sock", &self.sock)
+            .field("status", &self.status)
+            .field("conn", &"UnbufferedClientConnection")
+            .finish()
+    }
+}
+
+impl Drop for TlsConnection {
+    fn drop(&mut self) {
+        // fixme: Should I move the close logic here?
+        // if !self.status.connection_closed {
+        //     if let Err(e) = self.close_tls() {
+        //         log::error!("Error closing TLS connection: {:?}", e);
+        //    }
+        //}
+        if let Err(e) = self.sock.close() {
+            log::error!("Error closing VsockStream: {:?}", e);
+        }
+    }
+}
+
+/// Represents the possible actions that can be performed in the TLS state machine.
+#[derive(PartialEq)]
+enum TlsAction<'a> {
+    Handshake,
+    ReadRecord {
+        buffer: &'a mut [u8],
+        total_read: &'a mut usize,
+    },
+    WriteRecord {
+        buffer: &'a [u8],
+    },
+    CloseConnection,
+}
+
+/// Internal struct to track the state of the TLS connection
+#[derive(Debug)]
+struct ConnectionDetails {
+    handshake_complete: bool,
+    request_sent: bool,
+    received_response: bool,
+    peer_closed: bool,
+    our_side_closed: bool,
+    connection_closed: bool,
+}
+
+impl ConnectionDetails {
+    /// Create a new [`ConnectionDetails`] instance with default values
+    fn new() -> Self {
+        Self {
+            handshake_complete: false,
+            request_sent: false,
+            received_response: false,
+            peer_closed: false,
+            our_side_closed: false,
+            connection_closed: false,
+        }
+    }
+}

--- a/kernel/src/tls/constant.rs
+++ b/kernel/src/tls/constant.rs
@@ -1,0 +1,8 @@
+// Constants for TLS management
+pub const HEADER_LEN: usize = 5;
+pub const FIRST_LEN_BYTE_POS: usize = 4;
+pub const SECOND_LEN_BYTE_POS: usize = 3;
+const CONTENT_TYPE: usize = 1; // TLS ContentType field size in bytes
+const AEAD_OVERHEAD: usize = 16 + CONTENT_TYPE; // Bytes added by AEAD encryption
+pub const IN_BUF_SIZE: usize = 16 * 1024 + AEAD_OVERHEAD + HEADER_LEN;
+pub const OUT_BUF_SIZE: usize = 1024;

--- a/kernel/src/tls/crypto_provider/aead.rs
+++ b/kernel/src/tls/crypto_provider/aead.rs
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2016 Joseph Birr-Pixton <jpixton@gmail.com>
+//
+// Derived from the crypto-provider example in rustls (https://github.com/rustls/rustls/tree/main/provider-example)
+
+extern crate alloc;
+use alloc::boxed::Box;
+
+use rustls::{
+    crypto::cipher::{
+        make_tls13_aad, AeadKey, BorrowedPayload, InboundOpaqueMessage, InboundPlainMessage, Iv,
+        MessageDecrypter, MessageEncrypter, Nonce, OutboundOpaqueMessage, OutboundPlainMessage,
+        PrefixedPayload, Tls13AeadAlgorithm, UnsupportedOperationError,
+    },
+    ConnectionTrafficSecrets, ContentType, ProtocolVersion,
+};
+
+use aes_gcm::{
+    aead::{AeadInPlace, Buffer, Result as AeadResult},
+    KeyInit, KeySizeUser,
+};
+
+pub(crate) struct Aes128Gcm;
+
+impl Tls13AeadAlgorithm for Aes128Gcm {
+    fn encrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageEncrypter> {
+        Box::new(Tls13Cipher(
+            aes_gcm::Aes128Gcm::new_from_slice(key.as_ref()).unwrap(),
+            iv,
+        ))
+    }
+
+    fn decrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageDecrypter> {
+        Box::new(Tls13Cipher(
+            aes_gcm::Aes128Gcm::new_from_slice(key.as_ref()).unwrap(),
+            iv,
+        ))
+    }
+
+    fn key_len(&self) -> usize {
+        aes_gcm::Aes128Gcm::key_size()
+    }
+
+    fn extract_keys(
+        &self,
+        key: AeadKey,
+        iv: Iv,
+    ) -> Result<ConnectionTrafficSecrets, UnsupportedOperationError> {
+        Ok(ConnectionTrafficSecrets::Aes128Gcm { key, iv })
+    }
+}
+
+const AES_GCM_OVERHEAD: usize = 16;
+struct Tls13Cipher(aes_gcm::Aes128Gcm, Iv);
+
+impl MessageEncrypter for Tls13Cipher {
+    fn encrypt(
+        &mut self,
+        msg: OutboundPlainMessage<'_>,
+        seq: u64,
+    ) -> Result<OutboundOpaqueMessage, rustls::Error> {
+        let total_len = self.encrypted_payload_len(msg.payload.len());
+        let mut payload = PrefixedPayload::with_capacity(total_len);
+
+        payload.extend_from_chunks(&msg.payload);
+        payload.extend_from_slice(&msg.typ.to_array());
+
+        let nonce = Nonce::new(&self.1, seq);
+        let nonce = aes_gcm::Nonce::from(nonce.0);
+
+        let aad = make_tls13_aad(total_len);
+
+        self.0
+            .encrypt_in_place(&nonce, &aad, &mut EncryptBufferAdapter(&mut payload))
+            .map_err(|_| rustls::Error::EncryptError)
+            .map(|_| {
+                OutboundOpaqueMessage::new(
+                    ContentType::ApplicationData,
+                    ProtocolVersion::TLSv1_2,
+                    payload,
+                )
+            })
+    }
+
+    fn encrypted_payload_len(&self, payload_len: usize) -> usize {
+        payload_len + AES_GCM_OVERHEAD + 1
+    }
+}
+
+impl MessageDecrypter for Tls13Cipher {
+    fn decrypt<'a>(
+        &mut self,
+        mut msg: InboundOpaqueMessage<'a>,
+        seq: u64,
+    ) -> Result<InboundPlainMessage<'a>, rustls::Error> {
+        let payload = &mut msg.payload;
+
+        let nonce = Nonce::new(&self.1, seq);
+        let nonce = aes_gcm::Nonce::from(nonce.0);
+
+        let aad = make_tls13_aad(payload.len());
+
+        self.0
+            .decrypt_in_place(&nonce, &aad, &mut DecryptBufferAdapter(payload))
+            .map_err(|_| rustls::Error::DecryptError)?;
+
+        msg.into_tls13_unpadded_message()
+    }
+}
+
+struct EncryptBufferAdapter<'a>(&'a mut PrefixedPayload);
+
+impl AsRef<[u8]> for EncryptBufferAdapter<'_> {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl AsMut<[u8]> for EncryptBufferAdapter<'_> {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.0.as_mut()
+    }
+}
+
+impl Buffer for EncryptBufferAdapter<'_> {
+    fn extend_from_slice(&mut self, other: &[u8]) -> AeadResult<()> {
+        self.0.extend_from_slice(other);
+        Ok(())
+    }
+
+    fn truncate(&mut self, len: usize) {
+        self.0.truncate(len)
+    }
+}
+
+struct DecryptBufferAdapter<'a, 'p>(&'a mut BorrowedPayload<'p>);
+
+impl AsRef<[u8]> for DecryptBufferAdapter<'_, '_> {
+    fn as_ref(&self) -> &[u8] {
+        self.0
+    }
+}
+
+impl AsMut<[u8]> for DecryptBufferAdapter<'_, '_> {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.0
+    }
+}
+
+impl Buffer for DecryptBufferAdapter<'_, '_> {
+    fn extend_from_slice(&mut self, _: &[u8]) -> AeadResult<()> {
+        unreachable!("not used by `AeadInPlace::decrypt_in_place`")
+    }
+
+    fn truncate(&mut self, len: usize) {
+        self.0.truncate(len)
+    }
+}

--- a/kernel/src/tls/crypto_provider/hash.rs
+++ b/kernel/src/tls/crypto_provider/hash.rs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2016 Joseph Birr-Pixton <jpixton@gmail.com>
+//
+// Derived from the crypto-provider example in rustls (https://github.com/rustls/rustls/tree/main/provider-example)
+
+extern crate alloc;
+use alloc::boxed::Box;
+
+use rustls::crypto::hash;
+use sha2::Digest;
+
+pub(crate) struct Sha256;
+
+impl hash::Hash for Sha256 {
+    fn start(&self) -> Box<dyn hash::Context> {
+        Box::new(Sha256Context(sha2::Sha256::new()))
+    }
+
+    fn hash(&self, data: &[u8]) -> hash::Output {
+        hash::Output::new(&sha2::Sha256::digest(data)[..])
+    }
+
+    fn algorithm(&self) -> hash::HashAlgorithm {
+        hash::HashAlgorithm::SHA256
+    }
+
+    fn output_len(&self) -> usize {
+        32
+    }
+}
+
+struct Sha256Context(sha2::Sha256);
+
+impl hash::Context for Sha256Context {
+    fn fork_finish(&self) -> hash::Output {
+        hash::Output::new(&self.0.clone().finalize()[..])
+    }
+
+    fn fork(&self) -> Box<dyn hash::Context> {
+        Box::new(Self(self.0.clone()))
+    }
+
+    fn finish(self: Box<Self>) -> hash::Output {
+        hash::Output::new(&self.0.finalize()[..])
+    }
+
+    fn update(&mut self, data: &[u8]) {
+        self.0.update(data);
+    }
+}

--- a/kernel/src/tls/crypto_provider/hmac.rs
+++ b/kernel/src/tls/crypto_provider/hmac.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2016 Joseph Birr-Pixton <jpixton@gmail.com>
+//
+// Derived from the crypto-provider example in rustls (https://github.com/rustls/rustls/tree/main/provider-example)
+
+extern crate alloc;
+use alloc::boxed::Box;
+
+use hmac::{Hmac, Mac};
+use rustls::crypto;
+use sha2::{Digest, Sha256};
+
+pub(crate) struct Sha256Hmac;
+
+impl crypto::hmac::Hmac for Sha256Hmac {
+    fn with_key(&self, key: &[u8]) -> Box<dyn crypto::hmac::Key> {
+        Box::new(Sha256HmacKey(Hmac::<Sha256>::new_from_slice(key).unwrap()))
+    }
+
+    fn hash_output_len(&self) -> usize {
+        Sha256::output_size()
+    }
+}
+
+struct Sha256HmacKey(Hmac<Sha256>);
+
+impl crypto::hmac::Key for Sha256HmacKey {
+    fn sign_concat(&self, first: &[u8], middle: &[&[u8]], last: &[u8]) -> crypto::hmac::Tag {
+        let mut ctx = self.0.clone();
+        ctx.update(first);
+        for m in middle {
+            ctx.update(m);
+        }
+        ctx.update(last);
+        crypto::hmac::Tag::new(&ctx.finalize().into_bytes()[..])
+    }
+
+    fn tag_len(&self) -> usize {
+        Sha256::output_size()
+    }
+}

--- a/kernel/src/tls/crypto_provider/kx.rs
+++ b/kernel/src/tls/crypto_provider/kx.rs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2016 Joseph Birr-Pixton <jpixton@gmail.com>
+//
+// Derived from the crypto-provider example in rustls (https://github.com/rustls/rustls/tree/main/provider-example)
+
+extern crate alloc;
+use alloc::boxed::Box;
+
+use crypto::SupportedKxGroup;
+use ecdsa::signature::rand_core;
+use rustls::crypto;
+
+pub(crate) struct KeyExchange {
+    priv_key: x25519_dalek::EphemeralSecret,
+    pub_key: x25519_dalek::PublicKey,
+}
+
+impl crypto::ActiveKeyExchange for KeyExchange {
+    fn complete(self: Box<Self>, peer: &[u8]) -> Result<crypto::SharedSecret, rustls::Error> {
+        let peer_array: [u8; 32] = peer
+            .try_into()
+            .map_err(|_| rustls::Error::from(rustls::PeerMisbehaved::InvalidKeyShare))?;
+        let their_pub = x25519_dalek::PublicKey::from(peer_array);
+        let shared_secret = self.priv_key.diffie_hellman(&their_pub);
+        Ok(crypto::SharedSecret::from(&shared_secret.as_bytes()[..]))
+    }
+
+    fn pub_key(&self) -> &[u8] {
+        self.pub_key.as_bytes()
+    }
+
+    fn group(&self) -> rustls::NamedGroup {
+        X25519.name()
+    }
+}
+
+pub(crate) const ALL_KX_GROUPS: &[&dyn SupportedKxGroup] = &[&X25519];
+
+#[derive(Debug)]
+pub(crate) struct X25519;
+
+impl SupportedKxGroup for X25519 {
+    fn start(&self) -> Result<Box<dyn crypto::ActiveKeyExchange>, rustls::Error> {
+        let priv_key = x25519_dalek::EphemeralSecret::random_from_rng(rand_core::OsRng);
+        Ok(Box::new(KeyExchange {
+            pub_key: (&priv_key).into(),
+            priv_key,
+        }))
+    }
+
+    fn name(&self) -> rustls::NamedGroup {
+        rustls::NamedGroup::X25519
+    }
+}

--- a/kernel/src/tls/crypto_provider/mod.rs
+++ b/kernel/src/tls/crypto_provider/mod.rs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2016 Joseph Birr-Pixton <jpixton@gmail.com>
+//
+// Derived from the crypto-provider example in rustls (https://github.com/rustls/rustls/tree/main/provider-example)
+
+extern crate alloc;
+use alloc::sync::Arc;
+use rustls::crypto::CryptoProvider;
+use rustls::pki_types::PrivateKeyDer;
+
+mod aead;
+mod hash;
+mod hmac;
+mod kx;
+mod sign;
+mod verify;
+
+/// Returns a `CryptoProvider` that supports a limited set of cryptographic operations.
+pub fn provider() -> CryptoProvider {
+    CryptoProvider {
+        cipher_suites: ALL_CIPHER_SUITES.to_vec(),
+        kx_groups: kx::ALL_KX_GROUPS.to_vec(),
+        signature_verification_algorithms: verify::ALGORITHMS,
+        secure_random: &Provider,
+        key_provider: &Provider,
+    }
+}
+
+// The following is a RNG based on the cocoon_tpm_crypto crate. There is also a better version in
+// https://github.com/coconut-svsm/svsm/pull/806
+// For the moment, we use the OsRng from rand_core as a placeholder.
+// use cocoon_tpm_crypto::rng::ChainedRng;
+// use cocoon_tpm_crypto::rng::{test_rng, RngCore, X86RdSeedRng};
+// use cocoon_tpm_crypto::EmptyCryptoIoSlices;
+// use cocoon_tpm_utils_common::io_slices::{self, IoSlicesIterCommon};
+
+// #[derive(Debug)]
+// struct Provider;
+
+// impl rustls::crypto::SecureRandom for Provider {
+//     fn fill(&self, bytes: &mut [u8]) -> Result<(), rustls::crypto::GetRandomFailed> {
+//         let parent_rng =
+//             X86RdSeedRng::instantiate().map_err(|_| rustls::crypto::GetRandomFailed)?;
+//         let child_rng = test_rng();
+
+//         let mut chained_rng = ChainedRng::chain(parent_rng, child_rng);
+
+//         chained_rng
+//             .generate(
+//                 io_slices::SingletonIoSliceMut::new(bytes).map_infallible_err(),
+//                 None::<EmptyCryptoIoSlices>,
+//             )
+//             .map_err(|_| rustls::crypto::GetRandomFailed)
+//     }
+// }
+
+#[derive(Debug)]
+struct Provider;
+
+impl rustls::crypto::SecureRandom for Provider {
+    fn fill(&self, bytes: &mut [u8]) -> Result<(), rustls::crypto::GetRandomFailed> {
+        use rand_core::RngCore;
+        rand_core::OsRng
+            .try_fill_bytes(bytes)
+            .map_err(|_| rustls::crypto::GetRandomFailed)
+    }
+}
+
+impl rustls::crypto::KeyProvider for Provider {
+    fn load_private_key(
+        &self,
+        key_der: PrivateKeyDer<'static>,
+    ) -> Result<Arc<dyn rustls::sign::SigningKey>, rustls::Error> {
+        Ok(Arc::new(
+            sign::EcdsaSigningKeyP256::try_from(key_der)
+                .map_err(|err| rustls::Error::General(alloc::format!("{}", err)))?,
+        ))
+    }
+}
+
+static ALL_CIPHER_SUITES: &[rustls::SupportedCipherSuite] = &[rustls::SupportedCipherSuite::Tls13(
+    &rustls::Tls13CipherSuite {
+        common: rustls::crypto::CipherSuiteCommon {
+            suite: rustls::CipherSuite::TLS13_AES_128_GCM_SHA256,
+            hash_provider: &hash::Sha256,
+            confidentiality_limit: u64::MAX,
+        },
+        //protocol_version: rustls::version::TLS13_VERSION,
+        hkdf_provider: &rustls::crypto::tls13::HkdfUsingHmac(&hmac::Sha256Hmac),
+        aead_alg: &aead::Aes128Gcm,
+        quic: None,
+    },
+)];

--- a/kernel/src/tls/crypto_provider/sign.rs
+++ b/kernel/src/tls/crypto_provider/sign.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2016 Joseph Birr-Pixton <jpixton@gmail.com>
+//
+// Derived from the crypto-provider example in rustls (https://github.com/rustls/rustls/tree/main/provider-example)
+
+extern crate alloc;
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+
+use pkcs8::{DecodePrivateKey, EncodePublicKey};
+use rustls::pki_types::{PrivateKeyDer, SubjectPublicKeyInfoDer};
+use rustls::sign::{Signer, SigningKey};
+use rustls::{SignatureAlgorithm, SignatureScheme};
+use signature::{RandomizedSigner, SignatureEncoding};
+
+#[derive(Clone, Debug)]
+pub(crate) struct EcdsaSigningKeyP256 {
+    key: Arc<p256::ecdsa::SigningKey>,
+    scheme: SignatureScheme,
+}
+
+impl TryFrom<PrivateKeyDer<'_>> for EcdsaSigningKeyP256 {
+    type Error = pkcs8::Error;
+
+    fn try_from(value: PrivateKeyDer<'_>) -> Result<Self, Self::Error> {
+        match value {
+            PrivateKeyDer::Pkcs8(der) => {
+                p256::ecdsa::SigningKey::from_pkcs8_der(der.secret_pkcs8_der()).map(|kp| Self {
+                    key: Arc::new(kp),
+                    scheme: SignatureScheme::ECDSA_NISTP256_SHA256,
+                })
+            }
+            _ => panic!("unsupported private key format"),
+        }
+    }
+}
+
+impl SigningKey for EcdsaSigningKeyP256 {
+    fn choose_scheme(&self, offered: &[SignatureScheme]) -> Option<Box<dyn Signer>> {
+        if offered.contains(&self.scheme) {
+            Some(Box::new(self.clone()))
+        } else {
+            None
+        }
+    }
+
+    fn public_key(&self) -> Option<SubjectPublicKeyInfoDer<'_>> {
+        Some(SubjectPublicKeyInfoDer::from(
+            self.key
+                .verifying_key()
+                .to_public_key_der()
+                .ok()?
+                .into_vec(),
+        ))
+    }
+
+    fn algorithm(&self) -> SignatureAlgorithm {
+        SignatureAlgorithm::ECDSA
+    }
+}
+
+impl Signer for EcdsaSigningKeyP256 {
+    fn sign(&self, message: &[u8]) -> Result<Vec<u8>, rustls::Error> {
+        self.key
+            .try_sign_with_rng(&mut rand_core::OsRng, message)
+            .map_err(|_| rustls::Error::General("signing failed".into()))
+            .map(|sig: p256::ecdsa::DerSignature| sig.to_vec())
+    }
+
+    fn scheme(&self) -> SignatureScheme {
+        self.scheme
+    }
+}

--- a/kernel/src/tls/crypto_provider/verify.rs
+++ b/kernel/src/tls/crypto_provider/verify.rs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2016 Joseph Birr-Pixton <jpixton@gmail.com>
+//
+// Derived from the crypto-provider example in rustls (https://github.com/rustls/rustls/tree/main/provider-example)
+
+use der::Reader;
+use rsa::signature::Verifier;
+use rsa::{pkcs1v15, pss, BigUint, RsaPublicKey};
+use rustls::crypto::WebPkiSupportedAlgorithms;
+use rustls::pki_types::{
+    alg_id, AlgorithmIdentifier, InvalidSignature, SignatureVerificationAlgorithm,
+};
+use rustls::SignatureScheme;
+
+pub(crate) static ALGORITHMS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
+    all: &[RSA_PSS_SHA256, RSA_PKCS1_SHA256],
+    mapping: &[
+        (SignatureScheme::RSA_PSS_SHA256, &[RSA_PSS_SHA256]),
+        (SignatureScheme::RSA_PKCS1_SHA256, &[RSA_PKCS1_SHA256]),
+    ],
+};
+
+static RSA_PSS_SHA256: &dyn SignatureVerificationAlgorithm = &RsaPssSha256Verify;
+static RSA_PKCS1_SHA256: &dyn SignatureVerificationAlgorithm = &RsaPkcs1Sha256Verify;
+
+#[derive(Debug)]
+struct RsaPssSha256Verify;
+
+impl SignatureVerificationAlgorithm for RsaPssSha256Verify {
+    fn public_key_alg_id(&self) -> AlgorithmIdentifier {
+        alg_id::RSA_ENCRYPTION
+    }
+
+    fn signature_alg_id(&self) -> AlgorithmIdentifier {
+        alg_id::RSA_PSS_SHA256
+    }
+
+    fn verify_signature(
+        &self,
+        public_key: &[u8],
+        message: &[u8],
+        signature: &[u8],
+    ) -> Result<(), InvalidSignature> {
+        let public_key = decode_spki_spk(public_key)?;
+
+        let signature = pss::Signature::try_from(signature).map_err(|_| InvalidSignature)?;
+
+        pss::VerifyingKey::<sha2::Sha256>::new(public_key)
+            .verify(message, &signature)
+            .map_err(|_| InvalidSignature)
+    }
+}
+
+#[derive(Debug)]
+struct RsaPkcs1Sha256Verify;
+
+impl SignatureVerificationAlgorithm for RsaPkcs1Sha256Verify {
+    fn public_key_alg_id(&self) -> AlgorithmIdentifier {
+        alg_id::RSA_ENCRYPTION
+    }
+
+    fn signature_alg_id(&self) -> AlgorithmIdentifier {
+        alg_id::RSA_PKCS1_SHA256
+    }
+
+    fn verify_signature(
+        &self,
+        public_key: &[u8],
+        message: &[u8],
+        signature: &[u8],
+    ) -> Result<(), InvalidSignature> {
+        let public_key = decode_spki_spk(public_key)?;
+
+        let signature = pkcs1v15::Signature::try_from(signature).map_err(|_| InvalidSignature)?;
+
+        pkcs1v15::VerifyingKey::<sha2::Sha256>::new(public_key)
+            .verify(message, &signature)
+            .map_err(|_| InvalidSignature)
+    }
+}
+
+fn decode_spki_spk(spki_spk: &[u8]) -> Result<RsaPublicKey, InvalidSignature> {
+    // public_key: unfortunately this is not a whole SPKI, but just the key material.
+    // decode the two integers manually.
+    let mut reader = der::SliceReader::new(spki_spk).map_err(|_| InvalidSignature)?;
+    let ne: [der::asn1::UintRef<'_>; 2] = reader.decode().map_err(|_| InvalidSignature)?;
+
+    RsaPublicKey::new(
+        BigUint::from_bytes_be(ne[0].as_bytes()),
+        BigUint::from_bytes_be(ne[1].as_bytes()),
+    )
+    .map_err(|_| InvalidSignature)
+}

--- a/kernel/src/tls/error.rs
+++ b/kernel/src/tls/error.rs
@@ -1,0 +1,74 @@
+/// Errors specific to TLS operations
+#[derive(Clone, Copy, Debug)]
+pub enum TlsError {
+    HandshakeFailed,
+    InvalidMessage,
+    InvalidCertificate,
+    EncryptError,
+    DecryptError,
+    NoCertificates,
+    UnsupportedNameType,
+    GenericError,
+    ConnectionClosed,
+    InvalidDnsName,
+    EncodeError,
+    EarlyDataError,
+    FailedToGetRandomBytes,
+    MaxIterationsReached,
+    HandshakeNotComplete,
+    UnexpectedState,
+    BufferTooSmall,
+    IncompleteRead,
+    PeerClosed,
+    RequestAlreadySent,
+    ConnectionAlreadyClosed,
+}
+
+impl From<rustls::pki_types::InvalidDnsNameError> for TlsError {
+    fn from(_err: rustls::pki_types::InvalidDnsNameError) -> Self {
+        TlsError::InvalidDnsName
+    }
+}
+
+impl From<rustls::Error> for TlsError {
+    fn from(err: rustls::Error) -> Self {
+        use rustls::Error::*;
+        log::info!("Error from rustls: {:?}", err);
+        match err {
+            InappropriateMessage { .. } => TlsError::InvalidMessage,
+            InappropriateHandshakeMessage { .. } => TlsError::HandshakeFailed,
+            InvalidEncryptedClientHello(_) => TlsError::HandshakeFailed,
+            InvalidMessage(_) => TlsError::InvalidMessage,
+            NoCertificatesPresented => TlsError::NoCertificates,
+            UnsupportedNameType => TlsError::UnsupportedNameType,
+            DecryptError => TlsError::DecryptError,
+            EncryptError => TlsError::EncryptError,
+            PeerIncompatible(_) | PeerMisbehaved(_) | HandshakeNotComplete => {
+                TlsError::HandshakeFailed
+            }
+            InvalidCertificate(_) | InvalidCertRevocationList(_) => TlsError::InvalidCertificate,
+            General(_) => TlsError::GenericError,
+            FailedToGetCurrentTime => TlsError::GenericError,
+            FailedToGetRandomBytes => TlsError::FailedToGetRandomBytes,
+            PeerSentOversizedRecord | NoApplicationProtocol | BadMaxFragmentSize => {
+                TlsError::HandshakeFailed
+            }
+            AlertReceived(_) => TlsError::ConnectionClosed,
+            InconsistentKeys(_) => TlsError::HandshakeFailed,
+            Other(_) => TlsError::GenericError,
+            _ => TlsError::GenericError,
+        }
+    }
+}
+
+impl From<rustls::unbuffered::EncodeError> for TlsError {
+    fn from(_err: rustls::unbuffered::EncodeError) -> Self {
+        TlsError::EncodeError
+    }
+}
+
+impl From<rustls::unbuffered::EncryptError> for TlsError {
+    fn from(_err: rustls::unbuffered::EncryptError) -> Self {
+        TlsError::EncryptError
+    }
+}

--- a/kernel/src/tls/examples.rs
+++ b/kernel/src/tls/examples.rs
@@ -1,0 +1,172 @@
+// ########################################################
+// # Example functions to test the TLS connection
+// ########################################################
+
+extern crate alloc;
+
+use crate::error::SvsmError;
+use crate::vsock::virtio_vsock::VsockStream;
+
+use super::constant::IN_BUF_SIZE;
+
+const LOCAL_PORT: u32 = 1234;
+const REMOTE_PORT: u32 = 12345;
+const REMOTE_CID: u64 = 2;
+const SERVER_DNS: &str = "localhost";
+
+use super::connection::{TlsClient, TlsConnection};
+
+/// Test function to perform a simple HTTPS GET request over TLS
+pub fn test_https() {
+    log::info!("Opening TLS...");
+
+    let mut tls_connection = TlsClient::new(false)
+        .connect(
+            VsockStream::connect(LOCAL_PORT, REMOTE_PORT, REMOTE_CID)
+                .expect("Failed to connect to VsockStream"),
+            SERVER_DNS,
+        )
+        .expect("Failed to create TLS connection");
+
+    tls_connection
+        .complete_handshake()
+        .expect("Failed to complete TLS handshake");
+
+    let http_request =
+        "GET /hello.html HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n".as_bytes();
+
+    log::info!("########################################################");
+    log::info!("Sending HTTP request");
+    log::info!("########################################################");
+    tls_connection
+        .write_tls(http_request)
+        .expect("Failed to write application data over TLS");
+
+    log::info!("########################################################");
+    log::info!("Receiving HTTP response");
+    log::info!("########################################################");
+    let mut data_from_server = alloc::vec![0u8; IN_BUF_SIZE * 3]; // this is arbitrary
+
+    let total_len = read_command(&mut tls_connection, &mut data_from_server)
+        .expect("Failed to read application data over TLS");
+
+    let response = core::str::from_utf8(&data_from_server).unwrap_or("<Invalid UTF-8>");
+    log::info!("Total length: {}\n Response: \n {}", total_len, response);
+
+    log::info!("########################################################");
+    log::info!("Closing TLS connection");
+    log::info!("########################################################");
+    tls_connection
+        .close_tls()
+        .expect("Failed to close TLS connection");
+
+    log::info!("TLS conversation completed.");
+}
+
+/// Test function to interact with a command server over TLS
+/// The server is expected to send commands and wait for responses.
+/// The interaction continues until an "EXIT" command is received.  
+/// The server is expected to close the connection after sending the "EXIT" command.
+pub fn test_command_server() {
+    log::info!("Opening TLS...");
+
+    let mut tls_connection = TlsClient::new(false)
+        .connect(
+            VsockStream::connect(LOCAL_PORT, REMOTE_PORT, REMOTE_CID)
+                .expect("Failed to connect to VsockStream"),
+            SERVER_DNS,
+        )
+        .expect("Failed to create TLS connection");
+
+    log::info!("########################################################");
+    log::info!("Completing TLS handshake");
+    log::info!("########################################################");
+    tls_connection
+        .complete_handshake()
+        .expect("Failed to complete TLS handshake");
+
+    log::info!("########################################################");
+    log::info!("Entering command server read loop");
+    log::info!("########################################################");
+
+    let mut data_from_server = alloc::vec![0u8; IN_BUF_SIZE * 3];
+
+    loop {
+        log::info!("########################################################");
+        log::info!("Waiting for command server input");
+        log::info!("########################################################");
+
+        let total_len = read_command(&mut tls_connection, &mut data_from_server)
+            .expect("Failed to read application data over TLS");
+
+        if total_len == 0 {
+            log::info!("Peer closed the connection, exiting read loop");
+            break;
+        }
+
+        let response =
+            core::str::from_utf8(&data_from_server[..total_len]).unwrap_or("<Invalid UTF-8>");
+
+        log::info!("Received {} bytes:\n{}", total_len, response);
+        log::info!("########################################################");
+        log::info!("Sending response to command server");
+        log::info!("########################################################");
+
+        let response_message = b"Message received\n";
+        tls_connection
+            .write_tls(response_message)
+            .expect("Failed to write application data over TLS");
+
+        if response.contains("EXIT") {
+            log::info!("Received EXIT command, exiting read loop");
+            break;
+        } else {
+            log::info!("Received command: {}\n Continue", response);
+        }
+    }
+
+    log::info!("########################################################");
+    log::info!("Closing TLS connection");
+    log::info!("########################################################");
+    tls_connection
+        .close_tls()
+        .expect("Failed to close TLS connection");
+    log::info!("TLS conversation completed.");
+}
+
+fn read_command(tls_connection: &mut TlsConnection, buf: &mut [u8]) -> Result<usize, SvsmError> {
+    // read application data record from the server
+    // for the moment just one read
+    let mut iter_count = 1;
+    log::info!("Initial read iteration");
+    let mut total_read = 0;
+    let partial_read = tls_connection.read_tls(&mut buf[total_read..])?;
+
+    if partial_read == 0 {
+        log::info!("No data received from server");
+        return Ok(0);
+    }
+
+    total_read += partial_read;
+
+    // extract content-length from the HTTP response header
+    // for the moment just arbitrary number of reads
+    // what if the response header is not complete?
+
+    while iter_count < 1 {
+        // should use content-length to determine when to stop
+        log::info!("Read iteration {}", iter_count);
+        tls_connection
+            .read_tls(&mut buf[total_read..])
+            .map(|len| {
+                if len == 0 {
+                    return;
+                }
+                total_read += len;
+            })
+            .expect("Failed to read application data over TLS");
+        iter_count += 1;
+    }
+
+    Ok(total_read)
+}

--- a/kernel/src/tls/key_logger.rs
+++ b/kernel/src/tls/key_logger.rs
@@ -1,0 +1,29 @@
+extern crate alloc;
+use alloc::string::String;
+use rustls::KeyLog;
+
+/// A simple implementation of the [`KeyLog`] trait that logs TLS secrets using the log crate
+#[derive(Debug)]
+pub struct MyKeyLogger;
+
+impl KeyLog for MyKeyLogger {
+    /// Logs the TLS secrets.
+    fn log(&self, label: &str, client_random: &[u8], secret: &[u8]) {
+        fn hex(bytes: &[u8]) -> String {
+            let mut s = String::new();
+            for b in bytes {
+                s.push_str(&alloc::format!("{:02x}", b));
+            }
+            s
+        }
+
+        let msg = alloc::format!(
+            "{label} {client_random} {secret}",
+            label = label,
+            client_random = hex(client_random),
+            secret = hex(secret)
+        );
+
+        log::info!("KeyLog: {msg}");
+    }
+}

--- a/kernel/src/tls/mod.rs
+++ b/kernel/src/tls/mod.rs
@@ -8,4 +8,5 @@ mod time_provider;
 // Public modules for TLS implementation
 pub mod connection;
 pub mod error;
+pub mod examples;
 pub mod random;

--- a/kernel/src/tls/mod.rs
+++ b/kernel/src/tls/mod.rs
@@ -1,0 +1,11 @@
+// Private modules for TLS implementation
+mod buffer;
+mod constant;
+mod crypto_provider;
+mod key_logger;
+mod time_provider;
+
+// Public modules for TLS implementation
+pub mod connection;
+pub mod error;
+pub mod random;

--- a/kernel/src/tls/random.rs
+++ b/kernel/src/tls/random.rs
@@ -1,0 +1,40 @@
+use core::arch::asm;
+use getrandom::Error as GetRandomError;
+
+/// A custom implementation of a random number generator using the `rdrand` instruction on x86_64.
+/// This is a placeholder implementation.
+pub fn custom_getrandom(buf: &mut [u8]) -> Result<(), GetRandomError> {
+    for chunk in buf.chunks_mut(8) {
+        let mut rnd: u64;
+        let mut ok: u8;
+        let mut tries = 0;
+
+        loop {
+            // SAFETY: `rdrand` is safe to call on x86_64 processors that support it.
+            unsafe {
+                asm!(
+                    "rdrand {0}",
+                    "setc {1}",
+                    out(reg) rnd,
+                    out(reg_byte) ok,
+                );
+            }
+
+            if ok == 1 {
+                break;
+            }
+
+            tries += 1;
+            if tries > 10 {
+                return Err(GetRandomError::FAILED_RDRAND);
+            }
+        }
+
+        let bytes = rnd.to_ne_bytes();
+        for (b, r) in chunk.iter_mut().zip(bytes.iter()) {
+            *b = *r;
+        }
+    }
+
+    Ok(())
+}

--- a/kernel/src/tls/time_provider.rs
+++ b/kernel/src/tls/time_provider.rs
@@ -1,0 +1,36 @@
+use core::fmt::Debug;
+use core::time::Duration;
+use rustls::pki_types::UnixTime;
+use rustls::time_provider::TimeProvider;
+
+/// Rustls requires the user to provide a time provider.
+/// This implementation provides a fixed time for testing purposes.
+/// For the moment, we don't have a real time source.
+#[derive(Debug, Clone)]
+pub struct FixedTimeProvider {
+    fixed_time: UnixTime,
+}
+
+impl FixedTimeProvider {
+    /// Create a new [`FixedTimeProvider`] with a specific Unix timestamp (seconds since epoch)
+    pub fn new(timestamp_secs: u64) -> Self {
+        Self {
+            fixed_time: UnixTime::since_unix_epoch(Duration::from_secs(timestamp_secs)),
+        }
+    }
+
+    /// Create a new [`FixedTimeProvider`] with a timestamp set to December 2025
+    pub fn december_2025() -> Self {
+        const DECEMBER_2025: u64 = 1764979200; // Timestamp for December 6, 2025, 00:00:00 UTC
+        const _SEPTEMBER_2025: u64 = 1758283200; // Timestamp for September 19, 2025, 12:00:00 UTC
+        Self::new(DECEMBER_2025)
+    }
+}
+
+/// Implementation of the [`TimeProvider`] trait from rustls
+impl TimeProvider for FixedTimeProvider {
+    /// Returns the current timestamp, in this case a fixed value
+    fn current_time(&self) -> Option<UnixTime> {
+        Some(self.fixed_time)
+    }
+}

--- a/scripts/gen_ca_server_certs.sh
+++ b/scripts/gen_ca_server_certs.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+set -e 
+# --- Create output directory --- 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+OUTPUT_DIR="$(realpath "$SCRIPT_DIR/../certificates")"
+mkdir -p "$OUTPUT_DIR" 
+
+# --- Configs --- 
+ROOT_CA_NAME="Test Root CA" 
+ROOT_CA_COUNTRY="IT" 
+ROOT_CA_ORG="TestCA" 
+ROOT_CA_VALIDITY_DAYS=3650 
+ROOT_CA_STATE="Italy" 
+ROOT_CA_LOCALITY="Pisa"
+SERVER_NAME="localhost" 
+SERVER_IP="127.0.0.1"
+SERVER_COUNTRY="IT" 
+SERVER_ORG="TestServer" 
+SERVER_STATE="Italy"
+SERVER_LOCALITY="Pisa"
+SERVER_VALIDITY_DAYS=365 
+
+# File output 
+CA_KEY="$OUTPUT_DIR/ca.key" 
+CA_CERT="$OUTPUT_DIR/ca.crt" 
+CA_DER="$OUTPUT_DIR/ca.der" 
+SERVER_KEY="$OUTPUT_DIR/server.key" 
+SERVER_CSR="$OUTPUT_DIR/server.csr" 
+SERVER_CERT="$OUTPUT_DIR/server.crt" 
+SERVER_EXT="$OUTPUT_DIR/server_ext.cnf" 
+
+# --- 1. Create CA private key --- 
+echo "Creating CA private key..." 
+openssl genrsa -out "$CA_KEY" 4096 
+
+# --- 2. Create CA root certificate (self-signed) --- 
+echo "Creating CA root certificate..." 
+openssl req -x509 -new -nodes \
+    -key "$CA_KEY" \
+    -sha256 \
+    -days $ROOT_CA_VALIDITY_DAYS \
+    -out "$CA_CERT" \
+    -subj "/C=$ROOT_CA_COUNTRY/ST=$ROOT_CA_STATE/L=$ROOT_CA_LOCALITY/O=$ROOT_CA_ORG/CN=$ROOT_CA_NAME"   
+
+# --- 3. Convert CA certificate to DER for client ---
+echo "Converting CA certificate to DER format..." 
+openssl x509 \
+    -in "$CA_CERT" \
+    -outform der \
+    -out "$CA_DER"
+
+# --- 4. Create server private key --- 
+echo "Creating server private key..."
+openssl genrsa \
+    -out "$SERVER_KEY" \
+    2048
+
+# --- 5. Create SAN extensions file ---
+echo "Creating SAN extensions file..."
+cat > "$SERVER_EXT" <<EOL
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = $SERVER_NAME
+IP.1 = $SERVER_IP
+EOL
+
+# --- 6. Create server CSR (with SAN) ---
+echo "Creating server CSR..."
+openssl req -new \
+    -key "$SERVER_KEY" \
+    -out "$SERVER_CSR" \
+    -subj "/C=$SERVER_COUNTRY/ST=$SERVER_STATE/L=$SERVER_LOCALITY/O=$SERVER_ORG/CN=$SERVER_NAME" \
+    -config "$SERVER_EXT"
+
+# --- 7. Sign server certificate with CA --- 
+echo "Signing server certificate with CA..." 
+openssl x509 -req \
+    -in "$SERVER_CSR" \
+    -CA "$CA_CERT" \
+    -CAkey "$CA_KEY" \
+    -CAcreateserial \
+    -out "$SERVER_CERT" \
+    -days $SERVER_VALIDITY_DAYS \
+    -sha256 \
+    -extfile "$SERVER_EXT"
+
+echo "=== Operation completed ==="
+echo "CA certificate: $CA_CERT"
+echo "CA certificate (DER): $CA_DER"
+echo "Server certificate: $SERVER_CERT"
+echo "Server private key: $SERVER_KEY"

--- a/scripts/launch_https_test.sh
+++ b/scripts/launch_https_test.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+set -e
+trap cleanup EXIT INT TERM
+
+# --- Cleanup function to terminate background processes ---
+cleanup() {
+    echo "[*] Cleaning up background processes..."
+    for pid in "${pids[@]}"; do
+        if kill -0 "$pid" 2>/dev/null; then
+            kill "$pid"
+            wait "$pid" 2>/dev/null || true
+        fi
+    done
+
+    if [ -f "$HELLO_FILE" ]; then
+        rm  -f "$HELLO_FILE"
+    fi
+}
+
+# --- Flag default ---
+GEN_CERTS=true
+NO_COMPILE=false
+PORT=4433
+
+# --- Track background PIDs ---
+pids=()
+
+# --- Paths and files ---
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+OUTPUT_DIR=$(realpath "$SCRIPT_DIR/../certificates")
+CA_CERT="$OUTPUT_DIR/ca.crt"
+SERVER_CERT="$OUTPUT_DIR/server.crt"
+SERVER_KEY="$OUTPUT_DIR/server.key"
+HELLO_FILE="hello.html"
+
+# --- Parsing flags ---
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --no-gen-certs|-ng)
+            GEN_CERTS=false
+            shift
+            ;;
+        --port|-p)
+            PORT="$2"
+            shift 2
+            ;;
+        --no-compile|-nc)
+            NO_COMPILE=true
+            shift
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+# 1. Generate certificates if needed
+if [ "$GEN_CERTS" = true ]; then
+    rm -rf "$OUTPUT_DIR"
+    echo "[*] Generating new certificates..."
+    "$SCRIPT_DIR/gen_ca_server_certs.sh"
+else    
+    if [ ! -f "$CA_CERT" ] || [ ! -f "$SERVER_CERT" ] || [ ! -f "$SERVER_KEY" ]; then
+        echo "Error: Certificates not found in $OUTPUT_DIR. Please run without --no-gen-certs to generate them."
+        exit 1
+    else
+        echo "[*] Using existing certificates in $OUTPUT_DIR"
+    fi
+fi
+
+# 2. Build with TLS feature
+if [ "$NO_COMPILE" = true ]; then
+    echo "[*] Skipping compilation as per --no-compile flag."
+else
+    echo "[*] Building with TLS feature..."
+    make FEATURES=tls
+fi
+
+# 3. Start socat in background (output to file)
+echo "[*] Starting socat in background..."
+socat -d -d VSOCK-LISTEN:12345,reuseaddr TCP:localhost:$PORT > socat.log 2>&1 &
+
+# 4. Example file creation
+echo "Creating example file to serve..."
+echo "Hello, World!" > "$HELLO_FILE"
+
+# 5. Start openssl s_server in background (output to file)
+echo "[*] Starting openssl s_server in background..."
+openssl s_server \
+    -key "$SERVER_KEY" \
+    -cert "$SERVER_CERT" \
+    -port "$PORT" \
+    -tls1_3 \
+    -WWW \
+    -keylogfile tls_keylog.log \
+    > /dev/null 2>&1 &
+pids+=($!)
+
+# 6. Launch guest VM (this stays in foreground)
+echo "[*] Launching guest with QEMU=$QEMU ..."
+"$SCRIPT_DIR/launch_guest.sh" --nocc --vsock 3

--- a/tls_command_server/command_server.py
+++ b/tls_command_server/command_server.py
@@ -1,0 +1,97 @@
+import socket
+import ssl
+
+# TLS certificate and private key paths
+CERTFILE = './certificates/server.crt'
+KEYFILE = './certificates/server.key'
+
+# TCP/IP host and port
+HOST = "127.0.0.1"     # Listen on localhost
+PORT = 4433            # TLS server port
+
+BUFFER_SIZE = 4096
+
+def create_tls_context(certfile: str, keyfile: str, keylog_file: str = None) -> ssl.SSLContext:
+    """
+    Create and configure an SSL/TLS context for the server.
+    """
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(certfile=certfile, keyfile=keyfile)
+    if keylog_file:
+        context.keylog_filename = keylog_file  # Useful for Wireshark using TCP and not VSOCK
+    return context
+
+def receive_response(connstream: ssl.SSLSocket, buffer_size: int = BUFFER_SIZE) -> str:
+    """
+    Receive a response from the client.
+    Returns the decoded response string, or None if the client closed the connection.
+    """
+    data = connstream.recv(buffer_size)
+    if not data:
+        return None
+    return data.decode(errors='ignore')
+
+def handle_client(connstream: ssl.SSLSocket) -> None:
+    """
+    Handle the interaction with a single TLS client.
+    """
+    while True:
+        cmd = input("Command to send to client A ('EXIT' to close) > ") 
+        
+        if cmd.lower() == "shutdown":
+            connstream.unwrap()
+            break    
+        
+        # Send command
+        connstream.sendall(cmd.encode())
+
+        # Receive and print the client's response
+        response = receive_response(connstream)
+        if response:
+            print("[CLIENT A]:", response)
+        else:
+            print("[*] Client A closed the connection")
+            break
+        
+        if cmd.lower() == "exit" :
+            print("[*] EXIT command sent, closing connection")
+            connstream.unwrap()  # Perform TLS shutdown handshake
+            break
+
+def main():
+    """
+    TLS server that accepts a single client connection,
+    sends commands to the client, and receives responses.
+    """
+    # --- Socket creation ---
+    bindsocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    bindsocket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    bindsocket.bind((HOST, PORT))
+    bindsocket.listen(5)
+    print(f"[*] TLS server listening on {HOST}:{PORT}")
+
+    # --- SSL/TLS context ---
+    context = create_tls_context(CERTFILE, KEYFILE, keylog_file="tls_keylog.log")
+
+    # --- Accept client connection ---
+    newsocket, fromaddr = bindsocket.accept()
+    print(f"[*] Incoming TLS connection from {fromaddr}")
+
+    # Wrap the socket with TLS
+    connstream = context.wrap_socket(newsocket, server_side=True)
+
+    try:
+        handle_client(connstream)
+    except ssl.SSLError as e:
+        print("[!] SSL Error:", e)
+    except Exception as e:
+        print("[!] Error:", e)
+    except KeyboardInterrupt:
+        print("\n[*] Server interrupted by user")
+    finally:
+        connstream.close()
+        bindsocket.close()
+        print("[*] Connection closed")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR introduces initial TLS client functionality and provides tool for testing client connections

### Dependency

This PR depends on the following PRs: vsock support and mmio native support . Those commits are included here for testing.

### Implementation Details

The implementation is based on [rustls crate](https://docs.rs/rustls/latest/rustls/), which in no_std environment requires to implement `CryptoProvider` and `TimeProvider`. Due to the absence of a trusted time source,`TimeProvider` is implemented as a fixed source of time. The `CryptoProvider` is based on the example provided in the rustls repository for the moment.

Rustls offers an unbuffered API for `no_std`, which requires the user to manage all the buffers for TLS and plaintext data. The struct `TlsBuffer` was created for this purpose.

Other struct were introduced to help manage the TLS connection. In particular, `TlsClient` provides a way to build a `TlsConnection`,  which handles handshake, sending and receiving of application records and closing the connection (The core of the functionalities).

The `CryptoProvider` needs a random number generator. Currently, the getrandom crate with feature `custom` is used, but this is just a temporary solution. 

### Compilation
To compile the feature `tls` needs to be enabled.

A CA certificate must be present at compilation time.
If the cert is missing, the `insert_ca_cert()` function in `kernel/build.rs` calls the script `scripts/gen_ca_server_certs.sh`, which generates signed certificates for both a CA and a server. It is possible to run `scripts/gen_ca_server_certs.sh` directly to run tests.

### Testing
Two example function are provided and are commented inside `kernel/src/svsm.rs`. Uncomment one to use it:
- `test_https()`: does a single GET request to a web server(i.e. `openssl s_server -WWW ...`) and then closes the connection. To simplify the testing process, a simple script automates certificates creation, compilation and launch of socat  and openssl on the host.
- `test_command_server()`: connects to a python server (`tls_command_server/command_server.py`) from which it can receive "commands" to execute. For the moment are simple messages. It stops when it receives the `EXIT` command.

#### Notes
- The scripts provides a certificate starting from the current date. The time provider needs to provide a date within the certificate validity.
- The stack size needed to be increased due to a double panic during the call of some rustls api. 
- To work with the examples, on the host run:
  - `socat -d -d   VSOCK-LISTEN:12345,reuseaddr,fork   TCP:localhost:4433`
  - start a server (openssl or the python server) 
 - `TlsConnection`, with read and write methods, provides support for a single TLS record at the time. So if an application record is divided in more TLS records more read or write operations are required.

--- 