### PR TITLE
kernel/tests: Use quadword movement in asm

### DIFF
--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -1090,14 +1090,14 @@ mod tests {
     test_fpu:
         movq $0x3ff, %rax
         shl $52, %rax
-        // rax contains 1 in Double Precison FP representation
-        movd %rax, %xmm1
+        // rax contains 1.0 in Double Precison FP representation
+        movq %rax, %xmm1
         movapd %xmm1, %xmm3
 
         movq $0x400, %rax
         shl $52, %rax
-        // rax contains 2 in Double Precison FP representation
-        movd %rax, %xmm2
+        // rax contains 2.0 in Double Precison FP representation
+        movq %rax, %xmm2
 
         divsd %xmm2, %xmm3
         movq $0, %rax
@@ -1113,16 +1113,16 @@ mod tests {
         movq $1, %rax
         movq $0x3ff, %rbx
         shl $52, %rbx
-        // rbx contains 1 in Double Precison FP representation
-        movd %rbx, %xmm4
+        // rbx contains 1.0 in Double Precison FP representation
+        movq %rbx, %xmm4
         movapd %xmm4, %xmm6
         comisd %xmm4, %xmm1
         jnz 1f
 
         movq $0x400, %rbx
         shl $52, %rbx
-        // rbx contains 2 in Double Precison FP representation
-        movd %rbx, %xmm5
+        // rbx contains 2.0 in Double Precison FP representation
+        movq %rbx, %xmm5
         comisd %xmm5, %xmm2
         jnz 1f
 
@@ -1142,14 +1142,14 @@ mod tests {
     alter_fpu:
         movq $0x400, %rax
         shl $52, %rax
-        // rax contains 2 in Double Precison FP representation
-        movd %rax, %xmm1
+        // rax contains 2.0 in Double Precison FP representation
+        movq %rax, %xmm1
         movapd %xmm1, %xmm3
 
         movq $0x3ff, %rax
         shl $52, %rax
-        // rax contains 1 in Double Precison FP representation
-        movd %rax, %xmm2
+        // rax contains 1.0 in Double Precison FP representation
+        movq %rax, %xmm2
         divsd %xmm3, %xmm2
         movq $0, %rax
         ret

--- a/kernel/src/task/tasks.rs
+++ b/kernel/src/task/tasks.rs
@@ -1068,7 +1068,7 @@ fn task_exit() {
 #[cfg(all(test, test_in_svsm))]
 mod tests {
     extern crate alloc;
-    use crate::task::{KernelThreadStartInfo, start_kernel_task};
+    use crate::task::{KernelThreadStartInfo, start_kernel_task, wait_for_termination};
     use alloc::string::String;
     use core::arch::asm;
     use core::arch::global_asm;
@@ -1160,8 +1160,10 @@ mod tests {
     #[test]
     #[cfg_attr(not(test_in_svsm), ignore = "Can only be run inside guest")]
     fn test_fpu_context_switch() {
-        start_kernel_task(KernelThreadStartInfo::new(task1, 1), String::from("task1"))
+        let task1 = start_kernel_task(KernelThreadStartInfo::new(task1, 1), String::from("task1"))
             .expect("Failed to launch request processing task");
+
+        wait_for_termination(task1);
     }
 
     fn task1(start_parameter: usize) {


### PR DESCRIPTION
Currently, the code uses a double word movement to move the value of `rax`, but its content is on 64 bit and the most significant 32 bits are lost. This is a problem as they contain part of the floating point representation.

Use the quadword movement instead.